### PR TITLE
Revamp how GitHub/ZenHub rate limits are handled.

### DIFF
--- a/policybot/handlers/flakechaser/handler.go
+++ b/policybot/handlers/flakechaser/handler.go
@@ -17,9 +17,10 @@ package flakechaser
 import (
 	"net/http"
 
+	"github.com/google/go-github/v26/github"
+
 	"istio.io/bots/policybot/pkg/config"
 	"istio.io/bots/policybot/pkg/flakechaser"
-	"istio.io/bots/policybot/pkg/gh"
 	"istio.io/bots/policybot/pkg/storage"
 	"istio.io/bots/policybot/pkg/storage/cache"
 	"istio.io/pkg/log"
@@ -32,9 +33,9 @@ type handler struct {
 }
 
 // NewHandler creates a flake chaser.
-func NewHandler(ght *gh.ThrottledClient, store storage.Store, cache *cache.Cache, config config.FlakeChaser) http.Handler {
+func NewHandler(gc *github.Client, store storage.Store, cache *cache.Cache, config config.FlakeChaser) http.Handler {
 	return &handler{
-		chaser: flakechaser.New(ght, store, cache, config),
+		chaser: flakechaser.New(gc, store, cache, config),
 	}
 }
 

--- a/policybot/handlers/githubwebhook/filters/cfgmonitor/monitor.go
+++ b/policybot/handlers/githubwebhook/filters/cfgmonitor/monitor.go
@@ -22,13 +22,12 @@ import (
 	"github.com/google/go-github/v26/github"
 
 	"istio.io/bots/policybot/handlers/githubwebhook/filters"
-	"istio.io/bots/policybot/pkg/gh"
 	"istio.io/pkg/log"
 )
 
 // Monitors for changes in the bot's config file.
 type Monitor struct {
-	ght    *gh.ThrottledClient
+	gc     *github.Client
 	org    string
 	repo   string
 	branch string
@@ -38,7 +37,7 @@ type Monitor struct {
 
 var scope = log.RegisterScope("monitor", "Listens for changes in policybot config", 0)
 
-func NewMonitor(ght *gh.ThrottledClient, repo string, file string, notify func()) (filters.Filter, error) {
+func NewMonitor(gc *github.Client, repo string, file string, notify func()) (filters.Filter, error) {
 	if repo == "" {
 		// disable everything if we don't have a repo
 		return &Monitor{}, nil
@@ -50,7 +49,7 @@ func NewMonitor(ght *gh.ThrottledClient, repo string, file string, notify func()
 	}
 
 	ct := &Monitor{
-		ght:    ght,
+		gc:     gc,
 		org:    splits[0],
 		repo:   splits[1],
 		branch: splits[2],

--- a/policybot/handlers/syncer/handler.go
+++ b/policybot/handlers/syncer/handler.go
@@ -18,9 +18,10 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/google/go-github/v26/github"
+
 	"istio.io/bots/policybot/pkg/blobstorage"
 	"istio.io/bots/policybot/pkg/config"
-	"istio.io/bots/policybot/pkg/gh"
 	"istio.io/bots/policybot/pkg/storage"
 	"istio.io/bots/policybot/pkg/storage/cache"
 	"istio.io/bots/policybot/pkg/syncer"
@@ -31,10 +32,10 @@ type handler struct {
 	syncer *syncer.Syncer
 }
 
-func NewHandler(ctx context.Context, ght *gh.ThrottledClient, cache *cache.Cache,
-	zht *zh.ThrottledClient, store storage.Store, bs blobstorage.Store, orgs []config.Org) http.Handler {
+func NewHandler(ctx context.Context, gc *github.Client, cache *cache.Cache,
+	zc *zh.Client, store storage.Store, bs blobstorage.Store, orgs []config.Org) http.Handler {
 	return &handler{
-		syncer: syncer.New(ght, cache, zht, store, bs, orgs),
+		syncer: syncer.New(gc, cache, zc, store, bs, orgs),
 	}
 }
 

--- a/policybot/pkg/gh/convert.go
+++ b/policybot/pkg/gh/convert.go
@@ -28,7 +28,7 @@ func ConvertIssue(orgID string, repoID string, issue *api.Issue) (*storage.Issue
 		labels[i] = label.GetNodeID()
 	}
 
-	discoveredUsers := make([]*storage.User, len(issue.Assignees))
+	discoveredUsers := make([]*storage.User, 0, len(issue.Assignees))
 
 	assignees := make([]string, len(issue.Assignees))
 	for i, user := range issue.Assignees {
@@ -138,7 +138,7 @@ func ConvertPullRequest(orgID string, repoID string, pr *api.PullRequest, files 
 		labels[i] = label.GetNodeID()
 	}
 
-	discoveredUsers := make([]*storage.User, len(pr.Assignees)+len(pr.RequestedReviewers))
+	discoveredUsers := make([]*storage.User, 0, len(pr.Assignees)+len(pr.RequestedReviewers))
 
 	assignees := make([]string, len(pr.Assignees))
 	for i, user := range pr.Assignees {

--- a/policybot/pkg/zh/client.go
+++ b/policybot/pkg/zh/client.go
@@ -16,9 +16,11 @@ package zh
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
+	"strconv"
 	"time"
+
+	"github.com/google/go-github/v26/github"
 )
 
 const (
@@ -39,7 +41,13 @@ func NewClient(authToken string) *Client {
 
 var ErrNotFound = errors.New("requested resource not found")
 
-func (c *Client) sendRequest(method, urlPath string) (resp *http.Response, err error) {
+const (
+	headerRateLimit     = "X-RateLimit-Limit"
+	headerRateRemaining = "X-RateLimit-Remaining"
+	headerRateReset     = "X-RateLimit-Reset"
+)
+
+func (c *Client) sendRequest(method, urlPath string) (*http.Response, error) {
 	req, err := http.NewRequest(method, baseURL+urlPath, nil)
 	if err != nil {
 		return nil, err
@@ -55,18 +63,43 @@ func (c *Client) sendRequest(method, urlPath string) (resp *http.Response, err e
 		Timeout: timeout,
 	}
 
-	resp, err = client.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
+	}
+
+	if resp.StatusCode/100 == 2 {
+		return resp, nil
 	}
 
 	if resp.StatusCode == http.StatusNotFound {
 		return nil, ErrNotFound
 	}
 
-	if resp.StatusCode/100 != 2 {
-		return nil, fmt.Errorf("request failed with status code %d", resp.StatusCode)
+	if resp.StatusCode == http.StatusForbidden {
+		return nil, &github.RateLimitError{
+			Rate:     parseRate(resp),
+			Response: resp,
+			Message:  "Limit reached",
+		}
 	}
 
 	return resp, nil
+}
+
+// parseRate parses the rate related headers.
+func parseRate(r *http.Response) github.Rate {
+	var rate github.Rate
+	if limit := r.Header.Get(headerRateLimit); limit != "" {
+		rate.Limit, _ = strconv.Atoi(limit)
+	}
+	if remaining := r.Header.Get(headerRateRemaining); remaining != "" {
+		rate.Remaining, _ = strconv.Atoi(remaining)
+	}
+	if reset := r.Header.Get(headerRateReset); reset != "" {
+		if v, _ := strconv.ParseInt(reset, 10, 64); v != 0 {
+			rate.Reset = github.Timestamp{time.Unix(v, 0)}
+		}
+	}
+	return rate
 }


### PR DESCRIPTION
- We now use the GitHub/ZenHub return code to throttle access to
the API instead of having a client-side limit. This allows higher
burst perf, and works correctly when the bot scales up to more
than one pod.