### PR TITLE
Fix cron job specs.

### DIFF
--- a/policybot/deploy/kube/templates/cron-syncer-issues.yaml
+++ b/policybot/deploy/kube/templates/cron-syncer-issues.yaml
@@ -19,7 +19,8 @@ spec:
                 - syncer
                 - --config_file
                 - ./policybot.yaml
-                - --filter issues
+                - --filter
+                - issues
               envFrom:
                 - secretRef:
                     name: policybot

--- a/policybot/deploy/kube/templates/cron-syncer-misc.yaml
+++ b/policybot/deploy/kube/templates/cron-syncer-misc.yaml
@@ -19,7 +19,8 @@ spec:
                 - syncer
                 - --config_file
                 - ./policybot.yaml
-                - --filter maintainers,members,labels
+                - --filter
+                - maintainers,members,labels
               envFrom:
                 - secretRef:
                     name: policybot

--- a/policybot/deploy/kube/templates/cron-syncer-prs.yaml
+++ b/policybot/deploy/kube/templates/cron-syncer-prs.yaml
@@ -19,7 +19,8 @@ spec:
                 - syncer
                 - --config_file
                 - ./policybot.yaml
-                - --filter prs
+                - --filter
+                - prs
               envFrom:
                 - secretRef:
                     name: policybot

--- a/policybot/deploy/kube/templates/cron-syncer-zenhub.yaml
+++ b/policybot/deploy/kube/templates/cron-syncer-zenhub.yaml
@@ -19,7 +19,8 @@ spec:
                 - syncer
                 - --config_file
                 - ./policybot.yaml
-                - --filter zenhub
+                - --filter
+                - zenhub
               envFrom:
                 - secretRef:
                     name: policybot


### PR DESCRIPTION
- Didn't specify command-line arguments correctly, leading to errors.

- Fix refresher to avoid fetching files for a PR from GitHub on every PullRequestEvent by
being selective on the specific action. This eliminates the abuse error that GitHub was
producing as a result of having N concurrent calls to fetch the file list.