### PR TITLE
add support for pointer types in Spanner layer

### DIFF
--- a/policybot/pkg/storage/spanner/convert.go
+++ b/policybot/pkg/storage/spanner/convert.go
@@ -1,0 +1,98 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spanner
+
+import (
+	"fmt"
+	"reflect"
+	"time"
+
+	"cloud.google.com/go/spanner"
+)
+
+func readColumn(row *spanner.Row, f interface{}, sf reflect.StructField, t reflect.Type) error {
+	err := row.ColumnByName(sf.Name, f)
+	if err != nil {
+		return fmt.Errorf("rowToStruct: error deserializing into field %s in type %s: %v",
+			sf.Name, t.Name(), err)
+	}
+	return nil
+}
+
+func setValue(f reflect.Value, valid bool, val interface{}) {
+	if valid {
+		f.Set(reflect.ValueOf(val))
+	} else {
+		f.Set(reflect.Zero(f.Type()))
+	}
+}
+
+// rowToStruct converts a Spanner row into a storage struct. The Spanner
+// library requires use of Spanner-specific types for nullable columns, which
+// we don't want in our abstract layer. This function allows the use of
+// pointers to indicate null primitive columns. Null arrays are already handled
+// by the Spanner code. This code will return an error if a struct does not
+// have a corresponding column in the table, but will ignore columns that are
+// in Spanner and not in the struct.
+func rowToStruct(row *spanner.Row, s interface{}) error {
+	ptrType := reflect.TypeOf(s)
+	if ptrType.Kind() != reflect.Ptr || ptrType.Elem().Kind() != reflect.Struct {
+		return fmt.Errorf("rowToStruct: type %v must be a pointer to a struct", ptrType)
+	}
+	structType := ptrType.Elem()
+	structVal := reflect.ValueOf(s).Elem()
+	for i := 0; i < structType.NumField(); i++ {
+		fieldInfo := structType.Field(i)
+		if fieldInfo.PkgPath != "" { // field is unexported
+			continue
+		}
+		switch structVal.Field(i).Interface().(type) {
+		case *string:
+			ns := spanner.NullString{}
+			if err := readColumn(row, &ns, fieldInfo, structType); err != nil {
+				return err
+			}
+			setValue(structVal.Field(i), ns.Valid, &ns.StringVal)
+		case *int64:
+			ni := spanner.NullInt64{}
+			if err := readColumn(row, &ni, fieldInfo, structType); err != nil {
+				return err
+			}
+			setValue(structVal.Field(i), ni.Valid, &ni.Int64)
+		case *bool:
+			nb := spanner.NullBool{}
+			if err := readColumn(row, &nb, fieldInfo, structType); err != nil {
+				return err
+			}
+			setValue(structVal.Field(i), nb.Valid, &nb.Bool)
+		case *float64:
+			nf := spanner.NullFloat64{}
+			if err := readColumn(row, &nf, fieldInfo, structType); err != nil {
+				return err
+			}
+			setValue(structVal.Field(i), nf.Valid, &nf.Float64)
+		case *time.Time:
+			nt := spanner.NullTime{}
+			if err := readColumn(row, &nt, fieldInfo, structType); err != nil {
+				return err
+			}
+			setValue(structVal.Field(i), nt.Valid, &nt.Time)
+		default:
+			// Use the default behavior for non-nullable or non-primitive columns.
+			row.ColumnByName(fieldInfo.Name, structVal.Field(i).Addr().Interface())
+		}
+	}
+	return nil
+}

--- a/policybot/pkg/storage/spanner/convert.go
+++ b/policybot/pkg/storage/spanner/convert.go
@@ -62,36 +62,38 @@ func rowToStruct(row *spanner.Row, s interface{}) error {
 		case *string:
 			ns := spanner.NullString{}
 			if err := readColumn(row, &ns, fieldInfo, structType); err != nil {
-				return err
+				return fmt.Errorf("rowToStruct: error reading column %s: %v", fieldInfo.Name, err)
 			}
 			setValue(structVal.Field(i), ns.Valid, &ns.StringVal)
 		case *int64:
 			ni := spanner.NullInt64{}
 			if err := readColumn(row, &ni, fieldInfo, structType); err != nil {
-				return err
+				return fmt.Errorf("rowToStruct: error reading column %s: %v", fieldInfo.Name, err)
 			}
 			setValue(structVal.Field(i), ni.Valid, &ni.Int64)
 		case *bool:
 			nb := spanner.NullBool{}
 			if err := readColumn(row, &nb, fieldInfo, structType); err != nil {
-				return err
+				return fmt.Errorf("rowToStruct: error reading column %s: %v", fieldInfo.Name, err)
 			}
 			setValue(structVal.Field(i), nb.Valid, &nb.Bool)
 		case *float64:
 			nf := spanner.NullFloat64{}
 			if err := readColumn(row, &nf, fieldInfo, structType); err != nil {
-				return err
+				return fmt.Errorf("rowToStruct: error reading column %s: %v", fieldInfo.Name, err)
 			}
 			setValue(structVal.Field(i), nf.Valid, &nf.Float64)
 		case *time.Time:
 			nt := spanner.NullTime{}
 			if err := readColumn(row, &nt, fieldInfo, structType); err != nil {
-				return err
+				return fmt.Errorf("rowToStruct: error reading column %s: %v", fieldInfo.Name, err)
 			}
 			setValue(structVal.Field(i), nt.Valid, &nt.Time)
 		default:
 			// Use the default behavior for non-nullable or non-primitive columns.
-			row.ColumnByName(fieldInfo.Name, structVal.Field(i).Addr().Interface())
+			if err := row.ColumnByName(fieldInfo.Name, structVal.Field(i).Addr().Interface()); err != nil {
+				return fmt.Errorf("rowToStruct: error reading column %s: %v", fieldInfo.Name, err)
+			}
 		}
 	}
 	return nil

--- a/policybot/pkg/storage/spanner/convert_test.go
+++ b/policybot/pkg/storage/spanner/convert_test.go
@@ -1,0 +1,173 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spanner
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/spanner"
+)
+
+var (
+	nonNullString        = "nonNull"
+	nonNullInt64   int64 = 4321
+	nonNullBool          = false
+	nonNullFloat64       = 5432.1
+	now                  = time.Now().UTC() // Spanner returns UTC time.
+	nonNullTime          = now.Add(time.Hour)
+)
+
+func TestRowToStruct(t *testing.T) {
+	tests := []struct {
+		name     string
+		row      *spanner.Row
+		expected interface{}
+	}{
+		{
+			"nullString",
+			newRow(
+				t,
+				[]string{"ExistingCol", "NewCol"},
+				[]interface{}{"test", spanner.NullString{}}),
+			struct {
+				ExistingCol string
+				NewCol      *string
+			}{"test", nil},
+		},
+		{
+			"nonNullString",
+			newRow(
+				t,
+				[]string{"ExistingCol", "NewCol"},
+				[]interface{}{"test", spanner.NullString{Valid: true, StringVal: nonNullString}}),
+			struct {
+				ExistingCol string
+				NewCol      *string
+			}{"test", &nonNullString},
+		},
+		{
+			"nullInt64",
+			newRow(
+				t,
+				[]string{"ExistingCol", "NewCol"},
+				[]interface{}{1234, spanner.NullInt64{}}),
+			struct {
+				ExistingCol int64
+				NewCol      *int64
+			}{1234, nil},
+		},
+		{
+			"nonNullInt64",
+			newRow(
+				t,
+				[]string{"ExistingCol", "NewCol"},
+				[]interface{}{1234, spanner.NullInt64{Valid: true, Int64: nonNullInt64}}),
+			struct {
+				ExistingCol int64
+				NewCol      *int64
+			}{1234, &nonNullInt64},
+		},
+		{
+			"nullBool",
+			newRow(
+				t,
+				[]string{"ExistingCol", "NewCol"},
+				[]interface{}{true, spanner.NullBool{}}),
+			struct {
+				ExistingCol bool
+				NewCol      *bool
+			}{true, nil},
+		},
+		{
+			"nonNullBool",
+			newRow(
+				t,
+				[]string{"ExistingCol", "NewCol"},
+				[]interface{}{true, spanner.NullBool{Valid: true, Bool: false}}),
+			struct {
+				ExistingCol bool
+				NewCol      *bool
+			}{true, &nonNullBool},
+		},
+		{
+			"nullFloat64",
+			newRow(
+				t,
+				[]string{"ExistingCol", "NewCol"},
+				[]interface{}{1234.5, spanner.NullFloat64{}}),
+			struct {
+				ExistingCol float64
+				NewCol      *float64
+			}{1234.5, nil},
+		},
+		{
+			"nonNullFloat64",
+			newRow(
+				t,
+				[]string{"ExistingCol", "NewCol"},
+				[]interface{}{1234.5, spanner.NullFloat64{Valid: true, Float64: nonNullFloat64}}),
+			struct {
+				ExistingCol float64
+				NewCol      *float64
+			}{1234.5, &nonNullFloat64},
+		},
+		{
+			"nullTime",
+			newRow(
+				t,
+				[]string{"ExistingCol", "NewCol"},
+				[]interface{}{now, spanner.NullTime{}}),
+			struct {
+				ExistingCol time.Time
+				NewCol      *time.Time
+			}{now, nil},
+		},
+		{
+			"nonNullTime",
+			newRow(
+				t,
+				[]string{"ExistingCol", "NewCol"},
+				[]interface{}{now, spanner.NullTime{Valid: true, Time: nonNullTime}}),
+			struct {
+				ExistingCol time.Time
+				NewCol      *time.Time
+			}{now, &nonNullTime},
+		},
+	}
+
+	for _, test := range tests {
+		out := reflect.New(reflect.TypeOf(test.expected)).Interface()
+		if err := rowToStruct(test.row, out); err != nil {
+			t.Errorf("%s: error converting row to native struct: %v", test.name, err)
+		} else {
+			actual := reflect.ValueOf(out).Elem().Interface()
+			if !reflect.DeepEqual(actual, test.expected) {
+				t.Errorf("%s: converting row to native struct resulted in %v, but expected %v",
+					test.name, actual, test.expected)
+			}
+		}
+	}
+}
+
+func newRow(t *testing.T, names []string, vals []interface{}) *spanner.Row {
+	row, err := spanner.NewRow(names, vals)
+	if err != nil {
+		t.Errorf("error creating row with names %v and vals %v", names, vals)
+		return nil
+	}
+	return row
+}

--- a/policybot/pkg/storage/spanner/convert_test.go
+++ b/policybot/pkg/storage/spanner/convert_test.go
@@ -159,6 +159,16 @@ func TestRowToStruct(t *testing.T) {
 				NewCol      *time.Time
 			}{now, &nonNullTime},
 		},
+		{
+			"lessColumns",
+			newRow(
+				t,
+				[]string{"ExistingCol", "NewCol"},
+				[]interface{}{"test", spanner.NullString{Valid: true, StringVal: nonNullString}}),
+			struct {
+				ExistingCol string
+			}{"test"},
+		},
 	}
 
 	for _, test := range tests {

--- a/policybot/pkg/storage/spanner/query.go
+++ b/policybot/pkg/storage/spanner/query.go
@@ -29,7 +29,7 @@ func (s store) QueryMembersByOrg(context context.Context, orgLogin string, cb fu
 	iter := s.client.Single().Query(context, spanner.Statement{SQL: fmt.Sprintf("SELECT * FROM Members WHERE OrgLogin = '%s'", orgLogin)})
 	err := iter.Do(func(row *spanner.Row) error {
 		member := &storage.Member{}
-		if err := row.ToStruct(member); err != nil {
+		if err := rowToStruct(row, member); err != nil {
 			return err
 		}
 
@@ -43,7 +43,7 @@ func (s store) QueryMaintainersByOrg(context context.Context, orgLogin string, c
 	iter := s.client.Single().Query(context, spanner.Statement{SQL: fmt.Sprintf("SELECT * FROM Maintainers WHERE OrgLogin = '%s'", orgLogin)})
 	err := iter.Do(func(row *spanner.Row) error {
 		maintainer := &storage.Maintainer{}
-		if err := row.ToStruct(maintainer); err != nil {
+		if err := rowToStruct(row, maintainer); err != nil {
 			return err
 		}
 
@@ -58,7 +58,7 @@ func (s store) QueryIssuesByRepo(context context.Context, orgLogin string, repoN
 		spanner.Statement{SQL: fmt.Sprintf("SELECT * FROM Issues WHERE OrgLogin = '%s' AND RepoName = '%s';", orgLogin, repoName)})
 	err := iter.Do(func(row *spanner.Row) error {
 		issue := &storage.Issue{}
-		if err := row.ToStruct(issue); err != nil {
+		if err := rowToStruct(row, issue); err != nil {
 			return err
 		}
 
@@ -80,7 +80,7 @@ func (s store) QueryTestResultByTestName(context context.Context, orgLogin strin
 	iter := s.client.Single().Query(context, stmt)
 	err := iter.Do(func(row *spanner.Row) error {
 		testResult := &storage.TestResult{}
-		if err := row.ToStruct(testResult); err != nil {
+		if err := rowToStruct(row, testResult); err != nil {
 			return err
 		}
 

--- a/policybot/pkg/storage/spanner/read.go
+++ b/policybot/pkg/storage/spanner/read.go
@@ -32,7 +32,7 @@ func (s store) ReadOrg(context context.Context, orgLogin string) (*storage.Org, 
 	}
 
 	var result storage.Org
-	if err := row.ToStruct(&result); err != nil {
+	if err := rowToStruct(row, &result); err != nil {
 		return nil, err
 	}
 
@@ -48,7 +48,7 @@ func (s store) ReadRepo(context context.Context, orgLogin string, repoName strin
 	}
 
 	var result storage.Repo
-	if err := row.ToStruct(&result); err != nil {
+	if err := rowToStruct(row, &result); err != nil {
 		return nil, err
 	}
 
@@ -64,7 +64,7 @@ func (s store) ReadIssue(context context.Context, orgLogin string, repoName stri
 	}
 
 	var result storage.Issue
-	if err := row.ToStruct(&result); err != nil {
+	if err := rowToStruct(row, &result); err != nil {
 		return nil, err
 	}
 
@@ -81,7 +81,7 @@ func (s store) ReadIssueComment(context context.Context, orgLogin string, repoNa
 	}
 
 	var result storage.IssueComment
-	if err := row.ToStruct(&result); err != nil {
+	if err := rowToStruct(row, &result); err != nil {
 		return nil, err
 	}
 
@@ -97,7 +97,7 @@ func (s store) ReadIssuePipeline(context context.Context, orgLogin string, repoN
 	}
 
 	var result storage.IssuePipeline
-	if err := row.ToStruct(&result); err != nil {
+	if err := rowToStruct(row, &result); err != nil {
 		return nil, err
 	}
 
@@ -113,7 +113,7 @@ func (s store) ReadPullRequest(context context.Context, orgLogin string, repoNam
 	}
 
 	var result storage.PullRequest
-	if err := row.ToStruct(&result); err != nil {
+	if err := rowToStruct(row, &result); err != nil {
 		return nil, err
 	}
 
@@ -131,7 +131,7 @@ func (s store) ReadPullRequestReviewComment(context context.Context, orgLogin st
 	}
 
 	var result storage.PullRequestReviewComment
-	if err := row.ToStruct(&result); err != nil {
+	if err := rowToStruct(row, &result); err != nil {
 		return nil, err
 	}
 
@@ -149,7 +149,7 @@ func (s store) ReadPullRequestReview(context context.Context, orgLogin string, r
 	}
 
 	var result storage.PullRequestReview
-	if err := row.ToStruct(&result); err != nil {
+	if err := rowToStruct(row, &result); err != nil {
 		return nil, err
 	}
 
@@ -165,7 +165,7 @@ func (s store) ReadLabel(context context.Context, orgLogin string, repoName stri
 	}
 
 	var result storage.Label
-	if err := row.ToStruct(&result); err != nil {
+	if err := rowToStruct(row, &result); err != nil {
 		return nil, err
 	}
 
@@ -181,7 +181,7 @@ func (s store) ReadUser(context context.Context, userLogin string) (*storage.Use
 	}
 
 	var result storage.User
-	if err := row.ToStruct(&result); err != nil {
+	if err := rowToStruct(row, &result); err != nil {
 		return nil, err
 	}
 
@@ -197,7 +197,7 @@ func (s store) ReadBotActivity(context context.Context, orgLogin string, repoNam
 	}
 
 	var result storage.BotActivity
-	if err := row.ToStruct(&result); err != nil {
+	if err := rowToStruct(row, &result); err != nil {
 		return nil, err
 	}
 
@@ -213,7 +213,7 @@ func (s store) ReadTestResult(context context.Context, orgLogin string,
 		return nil, err
 	}
 	var result storage.TestResult
-	if err := row.ToStruct(&result); err != nil {
+	if err := rowToStruct(row, &result); err != nil {
 		return nil, err
 	}
 
@@ -229,7 +229,7 @@ func (s store) ReadMaintainer(context context.Context, orgLogin string, userLogi
 	}
 
 	var result storage.Maintainer
-	if err := row.ToStruct(&result); err != nil {
+	if err := rowToStruct(row, &result); err != nil {
 		return nil, err
 	}
 

--- a/policybot/pkg/storage/spanner/update.go
+++ b/policybot/pkg/storage/spanner/update.go
@@ -46,7 +46,7 @@ func (s store) UpdateBotActivity(ctx1 context.Context, orgLogin string, repoName
 			return err
 		}
 
-		mutation, err := spanner.InsertOrUpdateStruct(botActivityTable, &result)
+		mutation, err := insertOrUpdateStruct(botActivityTable, &result)
 		if err != nil {
 			return err
 		}

--- a/policybot/pkg/storage/spanner/update.go
+++ b/policybot/pkg/storage/spanner/update.go
@@ -37,7 +37,7 @@ func (s store) UpdateBotActivity(ctx1 context.Context, orgLogin string, repoName
 			result.RepoName = repoName
 		} else if err != nil {
 			return err
-		} else if err = row.ToStruct(&result); err != nil {
+		} else if err = rowToStruct(row, &result); err != nil {
 			return err
 		}
 

--- a/policybot/pkg/storage/spanner/write.go
+++ b/policybot/pkg/storage/spanner/write.go
@@ -28,7 +28,7 @@ func (s store) WriteOrgs(context context.Context, orgs []*storage.Org) error {
 	mutations := make([]*spanner.Mutation, len(orgs))
 	for i := 0; i < len(orgs); i++ {
 		var err error
-		if mutations[i], err = spanner.InsertOrUpdateStruct(orgTable, orgs[i]); err != nil {
+		if mutations[i], err = insertOrUpdateStruct(orgTable, orgs[i]); err != nil {
 			return err
 		}
 	}
@@ -43,7 +43,7 @@ func (s store) WriteRepos(context context.Context, repos []*storage.Repo) error 
 	mutations := make([]*spanner.Mutation, len(repos))
 	for i := 0; i < len(repos); i++ {
 		var err error
-		if mutations[i], err = spanner.InsertOrUpdateStruct(repoTable, repos[i]); err != nil {
+		if mutations[i], err = insertOrUpdateStruct(repoTable, repos[i]); err != nil {
 			return err
 		}
 	}
@@ -58,7 +58,7 @@ func (s store) WriteRepoComments(context context.Context, comments []*storage.Re
 	mutations := make([]*spanner.Mutation, len(comments))
 	for i := 0; i < len(comments); i++ {
 		var err error
-		if mutations[i], err = spanner.InsertOrUpdateStruct(repoCommentTable, comments[i]); err != nil {
+		if mutations[i], err = insertOrUpdateStruct(repoCommentTable, comments[i]); err != nil {
 			return err
 		}
 	}
@@ -73,7 +73,7 @@ func (s store) WriteIssues(context context.Context, issues []*storage.Issue) err
 	mutations := make([]*spanner.Mutation, len(issues))
 	for i := 0; i < len(issues); i++ {
 		var err error
-		if mutations[i], err = spanner.InsertOrUpdateStruct(issueTable, issues[i]); err != nil {
+		if mutations[i], err = insertOrUpdateStruct(issueTable, issues[i]); err != nil {
 			return err
 		}
 	}
@@ -88,7 +88,7 @@ func (s store) WriteIssueComments(context context.Context, issueComments []*stor
 	mutations := make([]*spanner.Mutation, len(issueComments))
 	for i := 0; i < len(issueComments); i++ {
 		var err error
-		if mutations[i], err = spanner.InsertOrUpdateStruct(issueCommentTable, issueComments[i]); err != nil {
+		if mutations[i], err = insertOrUpdateStruct(issueCommentTable, issueComments[i]); err != nil {
 			return err
 		}
 	}
@@ -103,7 +103,7 @@ func (s store) WriteIssuePipelines(context context.Context, issuePipelines []*st
 	mutations := make([]*spanner.Mutation, len(issuePipelines))
 	for i := 0; i < len(issuePipelines); i++ {
 		var err error
-		if mutations[i], err = spanner.InsertOrUpdateStruct(issuePipelineTable, issuePipelines[i]); err != nil {
+		if mutations[i], err = insertOrUpdateStruct(issuePipelineTable, issuePipelines[i]); err != nil {
 			return err
 		}
 	}
@@ -118,7 +118,7 @@ func (s store) WritePullRequests(context context.Context, prs []*storage.PullReq
 	mutations := make([]*spanner.Mutation, len(prs))
 	for i := 0; i < len(prs); i++ {
 		var err error
-		if mutations[i], err = spanner.InsertOrUpdateStruct(pullRequestTable, prs[i]); err != nil {
+		if mutations[i], err = insertOrUpdateStruct(pullRequestTable, prs[i]); err != nil {
 			return err
 		}
 	}
@@ -133,7 +133,7 @@ func (s store) WritePullRequestReviewComments(context context.Context, prComment
 	mutations := make([]*spanner.Mutation, len(prComments))
 	for i := 0; i < len(prComments); i++ {
 		var err error
-		if mutations[i], err = spanner.InsertOrUpdateStruct(pullRequestReviewCommentTable, prComments[i]); err != nil {
+		if mutations[i], err = insertOrUpdateStruct(pullRequestReviewCommentTable, prComments[i]); err != nil {
 			return err
 		}
 	}
@@ -148,7 +148,7 @@ func (s store) WritePullRequestReviews(context context.Context, prReviews []*sto
 	mutations := make([]*spanner.Mutation, len(prReviews))
 	for i := 0; i < len(prReviews); i++ {
 		var err error
-		if mutations[i], err = spanner.InsertOrUpdateStruct(pullRequestReviewTable, prReviews[i]); err != nil {
+		if mutations[i], err = insertOrUpdateStruct(pullRequestReviewTable, prReviews[i]); err != nil {
 			return err
 		}
 	}
@@ -163,7 +163,7 @@ func (s store) WriteUsers(context context.Context, users []*storage.User) error 
 	mutations := make([]*spanner.Mutation, len(users))
 	for i := 0; i < len(users); i++ {
 		var err error
-		if mutations[i], err = spanner.InsertOrUpdateStruct(userTable, users[i]); err != nil {
+		if mutations[i], err = insertOrUpdateStruct(userTable, users[i]); err != nil {
 			return err
 		}
 	}
@@ -178,7 +178,7 @@ func (s store) WriteLabels(context context.Context, labels []*storage.Label) err
 	mutations := make([]*spanner.Mutation, len(labels))
 	for i := 0; i < len(labels); i++ {
 		var err error
-		if mutations[i], err = spanner.InsertOrUpdateStruct(labelTable, labels[i]); err != nil {
+		if mutations[i], err = insertOrUpdateStruct(labelTable, labels[i]); err != nil {
 			return err
 		}
 	}
@@ -193,7 +193,7 @@ func (s store) WriteAllMembers(ctx1 context.Context, members []*storage.Member) 
 	mutations := make([]*spanner.Mutation, len(members))
 	for i, member := range members {
 		var err error
-		if mutations[i], err = spanner.InsertStruct(memberTable, member); err != nil {
+		if mutations[i], err = insertStruct(memberTable, member); err != nil {
 			return err
 		}
 	}
@@ -218,7 +218,7 @@ func (s store) WriteAllMaintainers(ctx1 context.Context, maintainers []*storage.
 	mutations := make([]*spanner.Mutation, len(maintainers))
 	for i, maintainer := range maintainers {
 		var err error
-		if mutations[i], err = spanner.InsertStruct(maintainerTable, maintainer); err != nil {
+		if mutations[i], err = insertStruct(maintainerTable, maintainer); err != nil {
 			return err
 		}
 	}
@@ -243,7 +243,7 @@ func (s store) WriteBotActivities(context context.Context, activities []*storage
 	mutations := make([]*spanner.Mutation, len(activities))
 	for i := 0; i < len(activities); i++ {
 		var err error
-		if mutations[i], err = spanner.InsertOrUpdateStruct(botActivityTable, activities[i]); err != nil {
+		if mutations[i], err = insertOrUpdateStruct(botActivityTable, activities[i]); err != nil {
 			return err
 		}
 	}
@@ -258,7 +258,7 @@ func (s store) WriteTestResults(context context.Context, testResults []*storage.
 	mutations := make([]*spanner.Mutation, len(testResults))
 	for i := 0; i < len(testResults); i++ {
 		var err error
-		if mutations[i], err = spanner.InsertOrUpdateStruct(testResultTable, testResults[i]); err != nil {
+		if mutations[i], err = insertOrUpdateStruct(testResultTable, testResults[i]); err != nil {
 			return err
 		}
 	}
@@ -273,7 +273,7 @@ func (s store) WriteIssueEvents(context context.Context, events []*storage.Issue
 	mutations := make([]*spanner.Mutation, len(events))
 	for i := 0; i < len(events); i++ {
 		var err error
-		if mutations[i], err = spanner.InsertOrUpdateStruct(issueEventTable, events[i]); err != nil {
+		if mutations[i], err = insertOrUpdateStruct(issueEventTable, events[i]); err != nil {
 			return err
 		}
 	}
@@ -288,7 +288,7 @@ func (s store) WriteIssueCommentEvents(context context.Context, events []*storag
 	mutations := make([]*spanner.Mutation, len(events))
 	for i := 0; i < len(events); i++ {
 		var err error
-		if mutations[i], err = spanner.InsertOrUpdateStruct(issueCommentEventTable, events[i]); err != nil {
+		if mutations[i], err = insertOrUpdateStruct(issueCommentEventTable, events[i]); err != nil {
 			return err
 		}
 	}
@@ -303,7 +303,7 @@ func (s store) WritePullRequestEvents(context context.Context, events []*storage
 	mutations := make([]*spanner.Mutation, len(events))
 	for i := 0; i < len(events); i++ {
 		var err error
-		if mutations[i], err = spanner.InsertOrUpdateStruct(pullRequestEventTable, events[i]); err != nil {
+		if mutations[i], err = insertOrUpdateStruct(pullRequestEventTable, events[i]); err != nil {
 			return err
 		}
 	}
@@ -318,7 +318,7 @@ func (s store) WritePullRequestReviewCommentEvents(context context.Context, even
 	mutations := make([]*spanner.Mutation, len(events))
 	for i := 0; i < len(events); i++ {
 		var err error
-		if mutations[i], err = spanner.InsertOrUpdateStruct(pullRequestReviewCommentEventTable, events[i]); err != nil {
+		if mutations[i], err = insertOrUpdateStruct(pullRequestReviewCommentEventTable, events[i]); err != nil {
 			return err
 		}
 	}
@@ -333,7 +333,7 @@ func (s store) WritePullRequestReviewEvents(context context.Context, events []*s
 	mutations := make([]*spanner.Mutation, len(events))
 	for i := 0; i < len(events); i++ {
 		var err error
-		if mutations[i], err = spanner.InsertOrUpdateStruct(pullRequestReviewEventTable, events[i]); err != nil {
+		if mutations[i], err = insertOrUpdateStruct(pullRequestReviewEventTable, events[i]); err != nil {
 			return err
 		}
 	}
@@ -348,7 +348,7 @@ func (s store) WriteRepoCommentEvents(context context.Context, events []*storage
 	mutations := make([]*spanner.Mutation, len(events))
 	for i := 0; i < len(events); i++ {
 		var err error
-		if mutations[i], err = spanner.InsertOrUpdateStruct(repoCommentEventTable, events[i]); err != nil {
+		if mutations[i], err = insertOrUpdateStruct(repoCommentEventTable, events[i]); err != nil {
 			return err
 		}
 	}

--- a/policybot/pkg/storage/types.go
+++ b/policybot/pkg/storage/types.go
@@ -18,7 +18,16 @@ import (
 	"time"
 )
 
-// This file defines the shapes we csn read/write to/from the DB.
+// This file defines the shapes we csn read/write to/from the DB. Before
+// adding a new column, it must pre-exist in Spanner. The order of steps
+// is as follows:
+//
+//     1. Add the column to Spanner (which must be nullable).
+//     2. Add the field with a pointer type to the storage struct, to
+//        allow nil value.
+//     3. Run syncer to populate the column.
+//     4. Convert the column to be not nullable.
+//     5. Change the pointer type to non pointer type in the struct.
 
 type Issue struct {
 	OrgLogin    string


### PR DESCRIPTION
This PR lets us add pointers to primitives in the storage layer. The Spanner layer converts these to and from the Go Spanner library's Null* types. It also allows a Spanner table to have more columns than the struct has fields, so in the future, we can do the following process to add columns to existing tables:

1. Add column to Spanner (which must be nullable)
2. Add pointer type to storage struct
3. Run syncer to populate the column
4. Convert column to be not nullable
5. Change pointer type to non pointer type in storage struct

Note that there is still no validation to confirm that a struct has a corresponding Spanner column, so this scenario will still fail.