### PR TITLE
abstract resultgatherer use of GCS into blobstorage

### DIFF
--- a/policybot/cmd/server.go
+++ b/policybot/cmd/server.go
@@ -22,10 +22,8 @@ import (
 	"net/http"
 	"time"
 
-	"cloud.google.com/go/storage"
 	"github.com/gorilla/mux"
 	"github.com/spf13/cobra"
-	"google.golang.org/api/option"
 	"google.golang.org/grpc/grpclog"
 
 	"istio.io/bots/policybot/dashboard"
@@ -208,11 +206,10 @@ func runWithConfig(a *config.Args) error {
 	}
 	defer store.Close()
 
-	cs, err := storage.NewClient(context.Background(), option.WithCredentialsJSON(creds))
+	bs, err := gcs.NewStore(context.Background(), creds)
 	if err != nil {
 		return fmt.Errorf("unable to create blob storage layer: %v", err)
 	}
-	bs := gcs.NewStore(cs)
 	defer bs.Close()
 
 	cache := cache.New(store, a.CacheTTL)

--- a/policybot/cmd/server.go
+++ b/policybot/cmd/server.go
@@ -22,8 +22,10 @@ import (
 	"net/http"
 	"time"
 
+	"cloud.google.com/go/storage"
 	"github.com/gorilla/mux"
 	"github.com/spf13/cobra"
+	"google.golang.org/api/option"
 	"google.golang.org/grpc/grpclog"
 
 	"istio.io/bots/policybot/dashboard"
@@ -206,10 +208,11 @@ func runWithConfig(a *config.Args) error {
 	}
 	defer store.Close()
 
-	bs, err := gcs.NewStore(context.Background(), creds)
+	cs, err := storage.NewClient(context.Background(), option.WithCredentialsJSON(creds))
 	if err != nil {
-		return fmt.Errorf("unable to create blob storage lsyer: %v", err)
+		return fmt.Errorf("unable to create blob storage layer: %v", err)
 	}
+	bs := gcs.NewStore(cs)
 	defer bs.Close()
 
 	cache := cache.New(store, a.CacheTTL)

--- a/policybot/handlers/githubwebhook/filters/resultgatherer/resultgatherer.go
+++ b/policybot/handlers/githubwebhook/filters/resultgatherer/resultgatherer.go
@@ -17,10 +17,10 @@ package resultgatherer
 import (
 	"context"
 
-	s "cloud.google.com/go/storage"
 	"github.com/google/go-github/v26/github"
 
 	"istio.io/bots/policybot/handlers/githubwebhook/filters"
+	"istio.io/bots/policybot/pkg/blobstorage"
 	"istio.io/bots/policybot/pkg/config"
 	gatherer "istio.io/bots/policybot/pkg/resultgatherer"
 	"istio.io/bots/policybot/pkg/storage"
@@ -38,15 +38,10 @@ type ResultGatherer struct {
 
 var scope = log.RegisterScope("ResultGatherer", "Result gatherer for each pr test run", 0)
 
-func NewResultGatherer(store storage.Store,
+func NewResultGatherer(store storage.Store, blobStore blobstorage.Store,
 	cache *cache.Cache, orgs []config.Org, bucketName string) filters.Filter {
-	ctx := context.Background()
 
-	client, err := s.NewClient(ctx)
-	if err != nil {
-		return nil
-	}
-	testResultGatherer, err := gatherer.NewTestResultGatherer(client, bucketName)
+	testResultGatherer, err := gatherer.NewTestResultGatherer(blobStore, bucketName)
 	if err != nil {
 		scope.Errorf(err.Error())
 		return nil

--- a/policybot/pkg/blobstorage/gcs/store.go
+++ b/policybot/pkg/blobstorage/gcs/store.go
@@ -16,12 +16,10 @@ package gcs
 
 import (
 	"context"
-	"fmt"
 	"io"
 
 	"cloud.google.com/go/storage"
 	"google.golang.org/api/iterator"
-	"google.golang.org/api/option"
 
 	"istio.io/bots/policybot/pkg/blobstorage"
 )
@@ -30,19 +28,10 @@ type store struct {
 	client *storage.Client
 }
 
-func NewStore(ctx context.Context, gcpCreds []byte) (blobstorage.Store, error) {
-	var opts []option.ClientOption
-	if gcpCreds != nil {
-		opts = append(opts, option.WithCredentialsJSON(gcpCreds))
-	}
-	client, err := storage.NewClient(ctx, opts...)
-	if err != nil {
-		return nil, fmt.Errorf("unable to create GCS client: %v", err)
-	}
-
+func NewStore(client *storage.Client) blobstorage.Store {
 	return &store{
 		client: client,
-	}, nil
+	}
 }
 
 func (s *store) Bucket(name string) blobstorage.Bucket {

--- a/policybot/pkg/blobstorage/gcs/store.go
+++ b/policybot/pkg/blobstorage/gcs/store.go
@@ -16,10 +16,12 @@ package gcs
 
 import (
 	"context"
+	"fmt"
 	"io"
 
 	"cloud.google.com/go/storage"
 	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
 
 	"istio.io/bots/policybot/pkg/blobstorage"
 )
@@ -28,10 +30,18 @@ type store struct {
 	client *storage.Client
 }
 
-func NewStore(client *storage.Client) blobstorage.Store {
+func NewStore(ctx context.Context, gcpCreds []byte) (blobstorage.Store, error) {
+	var opts []option.ClientOption
+	if gcpCreds != nil {
+		opts = append(opts, option.WithCredentialsJSON(gcpCreds))
+	}
+	client, err := storage.NewClient(ctx, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create GCS client: %v", err)
+	}
 	return &store{
 		client: client,
-	}
+	}, nil
 }
 
 func (s *store) Bucket(name string) blobstorage.Bucket {

--- a/policybot/pkg/blobstorage/store.go
+++ b/policybot/pkg/blobstorage/store.go
@@ -15,6 +15,7 @@
 package blobstorage
 
 import (
+	"context"
 	"io"
 )
 
@@ -22,5 +23,16 @@ import (
 type Store interface {
 	io.Closer
 
-	ReadBlob(path string) ([]byte, error)
+	Bucket(name string) Bucket
+}
+
+// Bucket represents a group of blobs.
+type Bucket interface {
+	Reader(ctx context.Context, path string) (io.ReadCloser, error)
+
+	// ListPrefixes returns a slice of prefixes that begin with the input
+	// prefix. This is roughly equivalent to a list of directories directly
+	// under a given prefix, though in blob storage systems, directories
+	// don't really exist.
+	ListPrefixes(ctx context.Context, prefix string) ([]string, error)
 }

--- a/policybot/pkg/resultgatherer/resultgatherer_test.go
+++ b/policybot/pkg/resultgatherer/resultgatherer_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	cslib "cloud.google.com/go/storage"
+
 	"istio.io/bots/policybot/pkg/blobstorage/gcs"
 	"istio.io/bots/policybot/pkg/resultgatherer"
 	"istio.io/bots/policybot/pkg/storage"

--- a/policybot/pkg/resultgatherer/resultgatherer_test.go
+++ b/policybot/pkg/resultgatherer/resultgatherer_test.go
@@ -21,8 +21,6 @@ import (
 	"testing"
 	"time"
 
-	cslib "cloud.google.com/go/storage"
-
 	"istio.io/bots/policybot/pkg/blobstorage/gcs"
 	"istio.io/bots/policybot/pkg/resultgatherer"
 	"istio.io/bots/policybot/pkg/storage"
@@ -53,11 +51,10 @@ func TestResultGatherer(t *testing.T) {
 	}
 	var prNum int64 = 110
 
-	cs, err := cslib.NewClient(context)
+	client, err := gcs.NewStore(context, nil)
 	if err != nil {
 		return
 	}
-	client := gcs.NewStore(cs)
 
 	testResultGatherer, err := resultgatherer.NewTestResultGatherer(client, "istio-flakey-test")
 	if err != nil {

--- a/policybot/pkg/resultgatherer/resultgatherer_test.go
+++ b/policybot/pkg/resultgatherer/resultgatherer_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	cslib "cloud.google.com/go/storage"
 	"istio.io/bots/policybot/pkg/blobstorage/gcs"
 	"istio.io/bots/policybot/pkg/resultgatherer"
 	"istio.io/bots/policybot/pkg/storage"
@@ -51,10 +52,11 @@ func TestResultGatherer(t *testing.T) {
 	}
 	var prNum int64 = 110
 
-	client, err := gcs.NewStore(context, nil)
+	cs, err := cslib.NewClient(context)
 	if err != nil {
 		return
 	}
+	client := gcs.NewStore(cs)
 
 	testResultGatherer, err := resultgatherer.NewTestResultGatherer(client, "istio-flakey-test")
 	if err != nil {

--- a/policybot/pkg/resultgatherer/resultgatherer_test.go
+++ b/policybot/pkg/resultgatherer/resultgatherer_test.go
@@ -21,8 +21,7 @@ import (
 	"testing"
 	"time"
 
-	store "cloud.google.com/go/storage"
-
+	"istio.io/bots/policybot/pkg/blobstorage/gcs"
 	"istio.io/bots/policybot/pkg/resultgatherer"
 	"istio.io/bots/policybot/pkg/storage"
 )
@@ -52,7 +51,7 @@ func TestResultGatherer(t *testing.T) {
 	}
 	var prNum int64 = 110
 
-	client, err := store.NewClient(context)
+	client, err := gcs.NewStore(context, nil)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
This change expands blobstorage interface abstraction to support all
of the operations currently used by resultgatherer. The test for
resultgatherer is still broken without credentials, but in the future
we can fake out GCS if we want to.