### PR TITLE
PolicyBot improvements

### DIFF
--- a/policybot/dashboard/topics/maintainers/assets.gen.go
+++ b/policybot/dashboard/topics/maintainers/assets.gen.go
@@ -47,10 +47,22 @@ func (fi bindataFileInfo) Sys() interface{} {
 	return nil
 }
 
-var _listHtml = []byte(`<p>
-These kind folks are responsible for specific areas of the Istio product, guiding its development
-and maintaining its code base.
+var _listHtml = []byte(`{{ if eq .Mode "inactive" }}
+    <p>
+        These kind folks are responsible for specific areas of the Istio product, guiding its development
+        and maintaining its code base, but they've been inactive in the project for the last {{ .ActivityDays }} days.
+    </p>
+{{ else if eq .Mode "emeritus" }}
+    <p>
+        These kind folks were previously responsible for specific areas of the Istio product, but have taken a leave of the project. We'd love
+        to have 'em back.
+    </p>
+{{ else }}
+<p>
+    These kind folks are responsible for specific areas of the Istio product, guiding its development
+    and maintaining its code base.
 </p>
+{{ end }}
 
 <div id="gallery" class="user-gallery active inactive">
 </div>

--- a/policybot/dashboard/topics/maintainers/list.html
+++ b/policybot/dashboard/topics/maintainers/list.html
@@ -1,7 +1,19 @@
+{{ if eq .Mode "inactive" }}
+    <p>
+        These kind folks are responsible for specific areas of the Istio product, guiding its development
+        and maintaining its code base, but they've been inactive in the project for the last {{ .ActivityDays }} days.
+    </p>
+{{ else if eq .Mode "emeritus" }}
+    <p>
+        These kind folks were previously responsible for specific areas of the Istio product, but have taken a leave of the project. We'd love
+        to have 'em back.
+    </p>
+{{ else }}
 <p>
-These kind folks are responsible for specific areas of the Istio product, guiding its development
-and maintaining its code base.
+    These kind folks are responsible for specific areas of the Istio product, guiding its development
+    and maintaining its code base.
 </p>
+{{ end }}
 
 <div id="gallery" class="user-gallery active inactive">
 </div>

--- a/policybot/pkg/storage/spanner/query.go
+++ b/policybot/pkg/storage/spanner/query.go
@@ -105,7 +105,7 @@ func (s store) QueryTestResultByPrNumber(
 	iter := s.client.Single().Query(context, stmt)
 	err := iter.Do(func(row *spanner.Row) error {
 		testResult := &storage.TestResult{}
-		if err := row.ToStruct(testResult); err != nil {
+		if err := rowToStruct(row, testResult); err != nil {
 			return err
 		}
 
@@ -126,7 +126,7 @@ func (s store) QueryTestResultByUndone(context context.Context, orgLogin string,
 	iter := s.client.Single().Query(context, stmt)
 	err := iter.Do(func(row *spanner.Row) error {
 		testResult := &storage.TestResult{}
-		if err := row.ToStruct(testResult); err != nil {
+		if err := rowToStruct(row, testResult); err != nil {
 			return err
 		}
 
@@ -147,7 +147,7 @@ func (s store) QueryAllTestResults(context context.Context, orgLogin string, rep
 	iter := s.client.Single().Query(context, stmt)
 	err := iter.Do(func(row *spanner.Row) error {
 		testResult := &storage.TestResult{}
-		if err := row.ToStruct(testResult); err != nil {
+		if err := rowToStruct(row, testResult); err != nil {
 			return err
 		}
 
@@ -172,7 +172,7 @@ func (s store) QueryTestFlakeIssues(context context.Context, inactiveDays, creat
 	var issues []*storage.Issue
 	getIssue := func(row *spanner.Row) error {
 		issue := storage.Issue{}
-		if err := row.ToStruct(&issue); err != nil {
+		if err := rowToStruct(row, &issue); err != nil {
 			return err
 		}
 		issues = append(issues, &issue)
@@ -225,7 +225,7 @@ func (s store) QueryMaintainerInfo(context context.Context, maintainer *storage.
 		err := iter.Do(func(row *spanner.Row) error {
 
 			var pr storage.PullRequest
-			if err := row.ToStruct(&pr); err != nil {
+			if err := rowToStruct(row, &pr); err != nil {
 				return err
 			}
 
@@ -288,7 +288,7 @@ func (s store) QueryMaintainerInfo(context context.Context, maintainer *storage.
 		err := iter.Do(func(row *spanner.Row) error {
 
 			var e storage.PullRequestReviewEvent
-			if err := row.ToStruct(&e); err != nil {
+			if err := rowToStruct(row, &e); err != nil {
 				return err
 			}
 
@@ -356,7 +356,7 @@ func (s store) QueryMaintainerInfo(context context.Context, maintainer *storage.
 		err := iter.Do(func(row *spanner.Row) error {
 
 			var e storage.PullRequestReviewCommentEvent
-			if err := row.ToStruct(&e); err != nil {
+			if err := rowToStruct(row, &e); err != nil {
 				return err
 			}
 
@@ -418,7 +418,7 @@ func (s store) QueryMaintainerInfo(context context.Context, maintainer *storage.
 			maintainer.OrgLogin, repoName, maintainer.UserLogin)})
 		err := iter.Do(func(row *spanner.Row) error {
 			var e storage.IssueCommentEvent
-			if err := row.ToStruct(&e); err != nil {
+			if err := rowToStruct(row, &e); err != nil {
 				return err
 			}
 
@@ -457,7 +457,7 @@ func (s store) QueryMaintainerInfo(context context.Context, maintainer *storage.
 			maintainer.UserLogin)})
 		err = iter.Do(func(row *spanner.Row) error {
 			var e storage.IssueEvent
-			if err := row.ToStruct(&e); err != nil {
+			if err := rowToStruct(row, &e); err != nil {
 				return err
 			}
 
@@ -491,7 +491,7 @@ func (s store) QueryMaintainerInfo(context context.Context, maintainer *storage.
 			maintainer.UserLogin)})
 		err = iter.Do(func(row *spanner.Row) error {
 			var e storage.IssueEvent
-			if err := row.ToStruct(&e); err != nil {
+			if err := rowToStruct(row, &e); err != nil {
 				return err
 			}
 


### PR DESCRIPTION
- Make sure the query code uses the custom row reading logic in Spanner
so it's tolerant of schema changes.

- Display different context info on the different maintainer filtered views.