### PR TITLE
PolicyBot improvements

### DIFF
--- a/policybot/Makefile
+++ b/policybot/Makefile
@@ -5,7 +5,7 @@ HUB ?= gcr.io/istio-testing/policybot
 IMG := $(HUB):$(TAG)
 export GO111MODULE=on
 
-dockerrun := docker run -t -i --sig-proxy=true --rm -v $(shell pwd):/site -w /site "gcr.io/istio-testing/website-builder:2019-05-03"
+dockerrun := docker run -t -i --sig-proxy=true --rm -v $(shell pwd):/site -w /site "gcr.io/istio-testing/website-tools:2019-07-25"
 
 gen:
 	@$(dockerrun) scripts/gen_dashboard.sh

--- a/policybot/cmd/server.go
+++ b/policybot/cmd/server.go
@@ -33,6 +33,7 @@ import (
 	"istio.io/bots/policybot/handlers/githubwebhook/filters/labeler"
 	"istio.io/bots/policybot/handlers/githubwebhook/filters/nagger"
 	"istio.io/bots/policybot/handlers/githubwebhook/filters/refresher"
+	"istio.io/bots/policybot/handlers/githubwebhook/filters/unstaler"
 	"istio.io/bots/policybot/handlers/zenhubwebhook"
 	"istio.io/bots/policybot/pkg/blobstorage/gcs"
 	"istio.io/bots/policybot/pkg/config"
@@ -214,6 +215,11 @@ func runWithConfig(a *config.Args) error {
 		return fmt.Errorf("unable to create labeler: %v", err)
 	}
 
+	unstaler, err := unstaler.NewUnstaler(gc, a.Orgs)
+	if err != nil {
+		return fmt.Errorf("unable to create unstaler: %v", err)
+	}
+
 	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", a.StartupOptions.Port))
 	if err != nil {
 		return fmt.Errorf("unable to listen to port: %v", err)
@@ -242,6 +248,7 @@ func runWithConfig(a *config.Args) error {
 	filters := []filters.Filter{
 		refresher.NewRefresher(cache, store, gc, a.Orgs),
 		nag,
+		unstaler,
 		labeler,
 		monitor,
 		//		resultgatherer.NewResultGatherer(store, cache, a.Orgs, a.BucketName),

--- a/policybot/cmd/syncer.go
+++ b/policybot/cmd/syncer.go
@@ -68,8 +68,8 @@ func syncerCmd() *cobra.Command {
 	syncerCmd.PersistentFlags().StringVarP(&ca.StartupOptions.GCPCredentials, "gcp_creds", "", ca.StartupOptions.GCPCredentials, gcpCreds)
 
 	syncerCmd.PersistentFlags().StringVarP(&filters,
-		// nolint: lll
-		"filter", "", "", "Comma-separated filters to limit what is synced, one or more of [issues, prs, labels, maintainers, members, zenhub, repocomments, testresults]")
+		"filter", "", "", "Comma-separated filters to limit what is synced, one or more of "+
+			"[issues, prs, labels, maintainers, members, zenhub, repocomments, events, testresults]")
 
 	loggingOptions.AttachCobraFlags(syncerCmd)
 

--- a/policybot/handlers/githubwebhook/filters/unstaler/unstaler.go
+++ b/policybot/handlers/githubwebhook/filters/unstaler/unstaler.go
@@ -1,0 +1,126 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package unstaler
+
+import (
+	"context"
+
+	"github.com/google/go-github/v26/github"
+
+	"istio.io/bots/policybot/handlers/githubwebhook/filters"
+	"istio.io/bots/policybot/pkg/config"
+	"istio.io/bots/policybot/pkg/gh"
+	"istio.io/pkg/log"
+)
+
+// Removes the staleness label and comments from issues and prs when activity is detected
+type Unstaler struct {
+	gc    *gh.ThrottledClient
+	repos map[string]bool
+}
+
+const stalenessLabel = "stale"
+const stalenessSignature = "\n\n_Courtesy of your friendly freshness tracker_."
+
+var scope = log.RegisterScope("unstale", "Removes the stale label when activity is detected on a PR or issue", 0)
+
+func NewUnstaler(gc *gh.ThrottledClient, orgs []config.Org) (filters.Filter, error) {
+	u := &Unstaler{
+		gc:    gc,
+		repos: make(map[string]bool),
+	}
+
+	for _, org := range orgs {
+		for _, repo := range org.Repos {
+			u.repos[org.Name+"/"+repo.Name] = true
+		}
+	}
+
+	return u, nil
+}
+
+// process an event arriving from GitHub
+func (u *Unstaler) Handle(context context.Context, event interface{}) {
+	action := ""
+	orgLogin := ""
+	repoName := ""
+	number := 0
+
+	switch p := event.(type) {
+	case *github.IssuesEvent:
+		scope.Infof("Received IssuesEvent: %s, %d, %s", p.GetRepo().GetFullName(), p.GetIssue().GetNumber(), p.GetAction())
+
+		action = p.GetAction()
+		orgLogin = p.GetRepo().GetOwner().GetLogin()
+		repoName = p.GetRepo().GetName()
+		number = p.GetIssue().GetNumber()
+
+	case *github.IssueCommentEvent:
+		scope.Infof("Received IssueCommentEvent: %s, %d, %s", p.GetRepo().GetFullName(), p.GetIssue().GetNumber(), p.GetAction())
+
+		action = p.GetAction()
+		orgLogin = p.GetRepo().GetOwner().GetLogin()
+		repoName = p.GetRepo().GetName()
+		number = p.GetIssue().GetNumber()
+
+	case *github.PullRequestEvent:
+		scope.Infof("Received PullRequestEvent: %s, %d, %s", p.GetRepo().GetFullName(), p.GetPullRequest().GetNumber(), p.GetAction())
+
+		action = p.GetAction()
+		orgLogin = p.GetRepo().GetOwner().GetLogin()
+		repoName = p.GetRepo().GetName()
+		number = p.GetPullRequest().GetNumber()
+
+	case *github.PullRequestReviewEvent:
+		scope.Infof("Received PullRequestReviewEvent: %s, %d, %s", p.GetRepo().GetFullName(), p.GetPullRequest().GetNumber(), p.GetAction())
+
+		action = p.GetAction()
+		orgLogin = p.GetRepo().GetOwner().GetLogin()
+		repoName = p.GetRepo().GetName()
+		number = p.GetPullRequest().GetNumber()
+
+	case *github.PullRequestReviewCommentEvent:
+		scope.Infof("Received PullRequestReviewCommentEvent: %s, %d, %s", p.GetRepo().GetFullName(), p.GetPullRequest().GetNumber(), p.GetAction())
+
+		action = p.GetAction()
+		orgLogin = p.GetRepo().GetOwner().GetLogin()
+		repoName = p.GetRepo().GetName()
+		number = p.GetPullRequest().GetNumber()
+
+	default:
+		// not what we're looking for
+		scope.Debugf("Unknown event received: %T %+v", p, p)
+		return
+	}
+
+	// see if the event is in a repo we're monitoring
+	if !u.repos[repoName+"/"+orgLogin] {
+		scope.Infof("Ignoring event for issue/PR %d from repo %s/%s since it's not in a monitored repo", number, orgLogin, repoName)
+		return
+	}
+
+	scope.Infof("Processing event for issue/PR %d from repo %s/%s, %s", number, repoName, orgLogin, action)
+
+	if _, err := u.gc.ThrottledCallNoResult(func(client *github.Client) (*github.Response, error) {
+		return client.Issues.RemoveLabelForIssue(context, orgLogin, repoName, number, stalenessLabel)
+	}); err != nil {
+		scope.Errorf("Unable to remove staleness label on issue/PR %d in repo %s/%s: %v", number, orgLogin, repoName, err)
+		return
+	}
+
+	if err := gh.RemoveBotComment(context, u.gc, orgLogin, repoName, number, stalenessSignature); err != nil {
+		scope.Error(err.Error())
+	}
+}

--- a/policybot/pkg/config/args.go
+++ b/policybot/pkg/config/args.go
@@ -101,7 +101,7 @@ type FlakeChaser struct {
 	// Name of the nag.
 	Name string
 
-	// InactiveDays represents the days that a flakey test issue hasn't been updated.
+	// InactiveDays represents the days that a flaky test issue hasn't been updated.
 	InactiveDays int
 
 	// CreatedDays determines the bot search range, only issues created within this days ago
@@ -137,8 +137,14 @@ type AutoLabel struct {
 	// AbsentLabels represents labels that must not be on the PR or issue
 	AbsentLabels []string // regexes
 
+	// PresentLabels represents labels that must be on the PR or issue
+	PresentLabels []string // regexes
+
 	// The labels to apply when any of the Match* expressions match and none of the Absent* expressions do.
-	Labels []string
+	LabelsToApply []string
+
+	// The labels to remove when any of the Match* expressions match and none of the Absent* expressions do.
+	LabelsToRemove []string
 }
 
 // Configuration for an individual repo.

--- a/policybot/pkg/gh/comments.go
+++ b/policybot/pkg/gh/comments.go
@@ -1,0 +1,112 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gh
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/go-github/v26/github"
+)
+
+// AddOrReplaceBotComment injects a comment from the bot into an issue or PR. It first removes any other
+// comment it finds with the same signature
+func AddOrReplaceBotComment(context context.Context, gc *ThrottledClient, orgLogin string, repoName string, number int, message string,
+	signature string) error {
+	msg := message + signature
+	pc := &github.IssueComment{
+		Body: &msg,
+	}
+
+	existing, id, err := FindBotComment(context, gc, orgLogin, repoName, number, signature)
+	if err != nil {
+		return err
+	}
+
+	if existing == msg {
+		// bot comment is already present
+		return nil
+	} else if existing != "" {
+		// try to delete the previous version
+		if _, err := gc.ThrottledCallNoResult(func(client *github.Client) (*github.Response, error) {
+			return client.Issues.DeleteComment(context, orgLogin, repoName, id)
+		}); err != nil {
+			return fmt.Errorf("unable to delete comment in issue/PR %d from repo %s/%s: %v", number, orgLogin, repoName, err)
+		}
+	}
+
+	_, _, err = gc.ThrottledCall(func(client *github.Client) (interface{}, *github.Response, error) {
+		return client.Issues.CreateComment(context, orgLogin, repoName, number, pc)
+	})
+
+	if err != nil {
+		return fmt.Errorf("unable to attach bot comment to issue/PR %d from repo %s/%s: %v", number, orgLogin, repoName, err)
+	}
+
+	return nil
+}
+
+// RemoveBotComment removes a comment from the bot in an issue or PR
+func RemoveBotComment(context context.Context, gc *ThrottledClient, orgLogin string, repoName string, number int, signature string) error {
+	existing, id, err := FindBotComment(context, gc, orgLogin, repoName, number, signature)
+	if err != nil {
+		return err
+	}
+
+	if existing != "" {
+		if _, err = gc.ThrottledCallNoResult(func(client *github.Client) (*github.Response, error) {
+			return client.Issues.DeleteComment(context, orgLogin, repoName, id)
+		}); err != nil {
+			return fmt.Errorf("unable to delete bot comment in issue/PR %d from repo %s/%s: %v", number, orgLogin, repoName, err)
+		}
+	}
+
+	return nil
+}
+
+// FindBotComment looks for a bot comment in an issue or PR
+func FindBotComment(context context.Context, gc *ThrottledClient, orgLogin string, repoName string, number int, signature string) (string, int64, error) {
+	opt := &github.IssueListCommentsOptions{
+		ListOptions: github.ListOptions{
+			PerPage: 100,
+		},
+	}
+
+	for {
+		comments, resp, err := gc.ThrottledCall(func(client *github.Client) (interface{}, *github.Response, error) {
+			return client.Issues.ListComments(context, orgLogin, repoName, number, opt)
+		})
+
+		if err != nil {
+			return "", -1, fmt.Errorf("unable to list comments for issue/PR %d in repo %s/%s: %v", number, orgLogin, repoName, err)
+		}
+
+		for _, comment := range comments.([]*github.IssueComment) {
+			body := comment.GetBody()
+			if strings.Contains(body, signature) {
+				return body, comment.GetID(), nil
+			}
+		}
+
+		if resp.NextPage == 0 {
+			break
+		}
+
+		opt.Page = resp.NextPage
+	}
+
+	return "", -1, nil
+}

--- a/policybot/pkg/storage/spanner/query.go
+++ b/policybot/pkg/storage/spanner/query.go
@@ -363,6 +363,8 @@ func (s store) QueryMaintainerActivity(context context.Context, maintainer *stor
 			pr, err := s.ReadPullRequest(context, maintainer.OrgLogin, repoName, int(e.PullRequestNumber))
 			if err != nil {
 				return err
+			} else if pr == nil {
+				return nil
 			}
 
 			// if the pr affects any files in any of the maintainer's paths, update the timed entry for the path

--- a/policybot/policybot.yaml
+++ b/policybot/policybot.yaml
@@ -26,13 +26,13 @@ flakechaser:
   repos:
     - "istio/istio"
 
-autolabels:
+autolabelstoapply:
   - name: Config
     matchbody:
       - "\\[ ?x ?\\] ?Configuration"
     absentlabels:
       - "area/.?"
-    labels:
+    labelstoapply:
       - area/config
 
   - name: Docs
@@ -40,7 +40,7 @@ autolabels:
       - "\\[ ?x ?\\] ?Docs"
     absentlabels:
       - "kind/.?"
-    labels:
+    labelstoapply:
       - kind/docs
 
   - name: Installation
@@ -48,7 +48,7 @@ autolabels:
       - "\\[ ?x ?\\] ?Installation"
     absentlabels:
       - "area/.?"
-    labels:
+    labelstoapply:
       - area/environments
 
   - name: Networking
@@ -56,7 +56,7 @@ autolabels:
       - "\\[ ?x ?\\] ?Networking"
     absentlabels:
       - "area/.?"
-    labels:
+    labelstoapply:
       - area/networking
 
   - name: Security
@@ -64,7 +64,7 @@ autolabels:
       - "\\[ ?x ?\\] ?Security"
     absentlabels:
       - "area/.?"
-    labels:
+    labelstoapply:
       - area/security
 
   - name: Test and Release
@@ -73,7 +73,7 @@ autolabels:
       - "\\[ ?x ?\\] ?Developer Infrastructure"
     absentlabels:
       - "area/.?"
-    labels:
+    labelstoapply:
       - "area/test and release"
 
   - name: Perf & Scalability
@@ -81,7 +81,7 @@ autolabels:
       - "\\[ ?x ?\\] ?Performance"
     absentlabels:
       - "area/.?"
-    labels:
+    labelstoapply:
       - "area/perf and scalability"
 
   - name: Policies and Telemetry
@@ -89,7 +89,7 @@ autolabels:
       - "\\[ ?x ?\\] ?Policies"
     absentlabels:
       - "area/.?"
-    labels:
+    labelstoapply:
       - "area/policies and telemetry"
 
   - name: UX
@@ -97,13 +97,13 @@ autolabels:
       - "\\[ ?x ?\\] ?User ?Experience"
     absentlabels:
       - "area/.?"
-    labels:
+    labelstoapply:
       - "area/user experience"
 
   - name: Feature Request
     matchbody:
       - "feature request"
-    labels:
+    labelstoapply:
       - kind/enhancement
 
 orgs:
@@ -172,6 +172,7 @@ orgs:
         description: Set by a human to override the Google CLA bot.
 
     repos:
+      - name: test-infra
       - name: istio.io
       - name: tools
       - name: api


### PR DESCRIPTION
- Implement the unstaler filter. It removes the stale label and comment if an issue
or PR is manipulated in any way. To be useful, I still need to implement the other
side of this which will mark issues/prs as stale with the Istio policy for such.

- Extend the labeler filter's functionality. It can now match prs & issues that have  a
specific set of labels, in addition to the previous negative matching. And it is now able
to remove labels in addition to being able to add them.