### PR TITLE
fix testresult syncer cron

### DIFF
--- a/policybot/deploy/kube/templates/cron-syncer-testresults.yaml
+++ b/policybot/deploy/kube/templates/cron-syncer-testresults.yaml
@@ -20,7 +20,7 @@ spec:
                 - --config_file
                 - ./policybot.yaml
                 - --filter
-                - TestResults
+                - testresults
               envFrom:
                 - secretRef:
                     name: policybot

--- a/policybot/pkg/syncer/syncer.go
+++ b/policybot/pkg/syncer/syncer.go
@@ -106,7 +106,7 @@ func ConvFilterFlags(filter string) (FilterFlags, error) {
 
 	var result FilterFlags
 	for _, f := range strings.Split(filter, ",") {
-		switch f {
+		switch strings.ToLower(f) {
 		case "issues":
 			result |= Issues
 		case "prs":

--- a/policybot/pkg/syncer/syncer_test.go
+++ b/policybot/pkg/syncer/syncer_test.go
@@ -1,0 +1,65 @@
+package syncer
+
+import (
+	"testing"
+)
+
+func TestConvFilterFlags(t *testing.T) {
+	tests := []struct {
+		flag     string
+		expected FilterFlags
+	}{
+		{
+			"notafilter",
+			0,
+		},
+		{
+			"issues",
+			Issues,
+		},
+		{
+			"prs",
+			Prs,
+		},
+		{
+			"members",
+			Members,
+		},
+		{
+			"labels",
+			Labels,
+		},
+		{
+			"zenhub",
+			ZenHub,
+		},
+		{
+			"repocomments",
+			RepoComments,
+		},
+		{
+			"events",
+			Events,
+		},
+		{
+			"testresults",
+			TestResults,
+		},
+		{
+			"issues,prs,maintainers,members,labels,zenhub,repocomments,events,testresults",
+			Issues | Prs | Maintainers | Members | Labels | ZenHub | RepoComments | Events | TestResults,
+		},
+		{
+			"Issues,PRs,mAiNtAinErS,MEMBERS,labeLs,zEnhUb,RePoComMents,EventS,TestResults",
+			Issues | Prs | Maintainers | Members | Labels | ZenHub | RepoComments | Events | TestResults,
+		},
+	}
+
+	for _, test := range tests {
+		actual, _ := ConvFilterFlags(test.flag)
+		if actual != test.expected {
+			t.Errorf("%s: converting to filter expected %d but returned %d",
+				test.flag, test.expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
Filter flags are now case insensitive, but the cron has been changed
to lower case "TestResult" anyway for consistency.
