### PR TITLE
use correct event type for test result filter

### DIFF
--- a/policybot/handlers/githubwebhook/filters/testresultfilter/testresultfilter.go
+++ b/policybot/handlers/githubwebhook/filters/testresultfilter/testresultfilter.go
@@ -135,7 +135,7 @@ func (r *TestResultFilter) getPrNumForSha(context context.Context, sha string) (
 	}
 	issues := resp.(*github.IssuesSearchResult).Issues
 	if len(issues) == 0 {
-		return 0, fmt.Errorf("No pull requests found for commit %s", sha)
+		return 0, fmt.Errorf("no pull requests found for commit %s", sha)
 	}
 	prNum := int64(issues[0].GetNumber())
 	r.shaToPrCache.Set(sha, prNum)


### PR DESCRIPTION
It is now confirmed, using istio/pkg, that Prow uses Github's Status
API, not the Check Runs API. This change adjusts the test result
filter use StatusEvents, which by nature have no PR info associated
with them (statuses are for commits, not PRs). This *should* work for
both commits on PRs and merge commits representing PRs, but the latter
is yet to be tested.