### PR TITLE
implement coverage gates and reporting

### DIFF
--- a/policybot/handlers/githubwebhook/filters/testresultfilter/testresultfilter.go
+++ b/policybot/handlers/githubwebhook/filters/testresultfilter/testresultfilter.go
@@ -95,7 +95,8 @@ func (r *TestResultFilter) Handle(context context.Context, event interface{}) {
 		orgLogin := p.GetOrganization().GetLogin()
 		prNum := p.GetNumber()
 		if p.GetAction() == "opened" || p.GetAction() == "synchronize" {
-			handlers.cov.SetCoverageStatus(context, p.GetPullRequest().GetHead().GetSHA(), coverage.Pending)
+			handlers.cov.SetCoverageStatus(context, p.GetPullRequest().GetHead().GetSHA(), coverage.Pending,
+				"Waiting for test results.")
 		}
 		testResults, err := handlers.trg.CheckTestResultsForPr(context, orgLogin, repoName, int64(prNum))
 		if err != nil {

--- a/policybot/pkg/coverage/config.go
+++ b/policybot/pkg/coverage/config.go
@@ -34,7 +34,7 @@ type Feature struct {
 }
 
 type Stage struct {
-	Targets  map[string]int
+	Targets  map[string]float64
 	Packages []string
 }
 
@@ -63,7 +63,7 @@ func GetConfig(org, repo string) (Config, error) {
 	}
 	for _, f := range cfg {
 		for _, s := range f.Stages {
-			normalized := make(map[string]int)
+			normalized := make(map[string]float64)
 			for label, target := range s.Targets {
 				normalized[normalizeLabel(label)] = target
 			}

--- a/policybot/pkg/coverage/config_test.go
+++ b/policybot/pkg/coverage/config_test.go
@@ -43,7 +43,7 @@ func TestGetCustomLabels(t *testing.T) {
 			"feature": &Feature{
 				Stages: map[string]*Stage{
 					"alpha": {
-						Targets: map[string]int{
+						Targets: map[string]float64{
 							"unit":      90,
 							"e2e+integ": 90,
 						},

--- a/policybot/pkg/coverage/coverage.go
+++ b/policybot/pkg/coverage/coverage.go
@@ -149,7 +149,9 @@ func (c *Client) CheckCoverage(ctx context.Context, pr *github.PullRequest, sha 
 	c.SetCoverageStatus(ctx, sha, res.GetGithubStatus(), res.GetDescription())
 	comment := res.GetComment()
 	if comment != "" {
-		gh.AddOrReplaceBotComment(ctx, c.GithubClient, c.OrgLogin, c.Repo, pr.GetNumber(), comment, signature)
+		if err := gh.AddOrReplaceBotComment(ctx, c.GithubClient, c.OrgLogin, c.Repo, pr.GetNumber(), comment, signature); err != nil {
+			return fmt.Errorf("coverage: error writing Github comment: %v", err)
+		}
 	}
 	return nil
 }

--- a/policybot/pkg/coverage/diff.go
+++ b/policybot/pkg/coverage/diff.go
@@ -1,0 +1,165 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package coverage
+
+import (
+	"context"
+	"strings"
+
+	"github.com/google/go-github/v26/github"
+	"istio.io/bots/policybot/pkg/storage"
+)
+
+type cov struct {
+	covered, total int64
+}
+
+type DiffResultEntry struct {
+	Feature, Stage, Label string
+	Target, Actual        int
+}
+
+type DiffResult struct {
+	err     error
+	Entries []*DiffResultEntry
+}
+
+// GetGithubStatus returns the Github status string for the DiffResult.
+func (d DiffResult) GetGithubStatus() string {
+	if d.err != nil {
+		return Error
+	}
+	if len(d.Entries) > 0 {
+		return Failure
+	}
+	return Success
+}
+
+// GetDescription returns the one line description string for the DiffResult.
+func (d DiffResult) GetDescription() string {
+	s := d.GetGithubStatus()
+	if s == Success {
+		return "All coverage checks passed."
+	}
+	if s == Failure {
+		return "Some coverage targets were not met."
+	}
+	return "Error while computing code coverage."
+}
+
+// GetComment returns a comment for the bot to post on a PR thread, if any.
+// A blank string means no comment should be posted.
+func (d DiffResult) GetComment() string {
+	s := d.GetGithubStatus()
+	if s == Success {
+		return ""
+	}
+	if s == Failure {
+
+	}
+	return "An internal error occurred while computing coverage. Please file an issue for investigation."
+}
+
+func (c *Client) checkCoverageDiff(
+	ctx context.Context,
+	pr *github.PullRequest,
+	sha string,
+) *DiffResult {
+	cfg, err := GetConfig(c.OrgLogin, c.Repo)
+	if err != nil {
+		return &DiffResult{err: err}
+	}
+	if cfg == nil || len(cfg) == 0 {
+		return &DiffResult{}
+	}
+	baseSHA := pr.GetBase().GetSHA()
+	baseCoverage, err := c.getCoverageData(ctx, baseSHA)
+	if err != nil {
+		return &DiffResult{err: err}
+	}
+	coverage, err := c.getCoverageData(ctx, sha)
+	if err != nil {
+		return &DiffResult{err: err}
+	}
+
+	result := &DiffResult{}
+	for featureName, feature := range cfg {
+		for stageName, stage := range feature.Stages {
+			base := make(map[string]*cov)
+			curr := make(map[string]*cov)
+			for _, stagePkg := range stage.Packages {
+				// Perhaps we can do better than this.
+				for pkg, covs := range baseCoverage {
+					if strings.HasPrefix(pkg, stagePkg) {
+						updateCov(base, covs)
+					}
+				}
+				for pkg, covs := range coverage {
+					if strings.HasPrefix(pkg, stagePkg) {
+						updateCov(curr, covs)
+					}
+				}
+			}
+			for label, target := range stage.Targets {
+				if cov, ok := curr[label]; ok {
+					pct := cov.covered * 100 / cov.total
+					if pct < int64(target) {
+						result.Entries = append(result.Entries, &DiffResultEntry{
+							Feature: featureName,
+							Stage:   stageName,
+							Label:   label,
+							Target:  target,
+							Actual:  int(pct),
+						})
+					}
+				} else {
+					result.Entries = append(result.Entries, &DiffResultEntry{
+						Feature: featureName,
+						Stage:   stageName,
+						Label:   label,
+						Target:  target,
+						Actual:  0,
+					})
+				}
+			}
+		}
+	}
+
+	return result
+}
+
+func (c *Client) getCoverageData(ctx context.Context, sha string) (map[string][]*storage.CoverageData, error) {
+	var data map[string][]*storage.CoverageData
+	err := c.StorageClient.QueryCoverageDataBySHA(
+		ctx, c.OrgLogin, c.Repo, sha,
+		func(result *storage.CoverageData) error {
+			data[result.PackageName] = append(data[result.PackageName], result)
+			return nil
+		})
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+func updateCov(covs map[string]*cov, profs []*storage.CoverageData) {
+	for _, prof := range profs {
+		if _, ok := covs[prof.Type]; !ok {
+			covs[prof.Type] = &cov{}
+		}
+		covs[prof.Type].covered += prof.StmtsCovered
+		covs[prof.Type].total += prof.StmtsTotal
+	}
+}

--- a/policybot/pkg/coverage/diff.go
+++ b/policybot/pkg/coverage/diff.go
@@ -28,7 +28,7 @@ type cov struct {
 
 type DiffResultEntry struct {
 	Feature, Stage, Label string
-	Target, Actual        int
+	Target, Actual, Base  float64
 }
 
 type DiffResult struct {
@@ -144,24 +144,22 @@ func computeDiffResult(
 				}
 			}
 			for label, target := range stage.Targets {
+				pct := 0.0
 				if cov, ok := curr[label]; ok {
-					pct := cov.covered * 100 / cov.total
-					if pct < int64(target) {
-						result.Entries = append(result.Entries, &DiffResultEntry{
-							Feature: featureName,
-							Stage:   stageName,
-							Label:   label,
-							Target:  target,
-							Actual:  int(pct),
-						})
-					}
-				} else {
+					pct = float64(cov.covered) * 100 / float64(cov.total)
+				}
+				basePct := 0.0
+				if baseCov, ok := base[label]; ok {
+					basePct = float64(baseCov.covered) * 100 / float64(baseCov.total)
+				}
+				if pct < target {
 					result.Entries = append(result.Entries, &DiffResultEntry{
 						Feature: featureName,
 						Stage:   stageName,
 						Label:   label,
 						Target:  target,
-						Actual:  0,
+						Actual:  pct,
+						Base:    basePct,
 					})
 				}
 			}

--- a/policybot/pkg/coverage/diff.go
+++ b/policybot/pkg/coverage/diff.go
@@ -16,6 +16,7 @@ package coverage
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/google/go-github/v26/github"
@@ -67,7 +68,14 @@ func (d DiffResult) GetComment() string {
 		return ""
 	}
 	if s == Failure {
-
+		b := strings.Builder{}
+		b.WriteString("Coverage checks failed:\n\n")
+		for _, entry := range d.Entries {
+			b.WriteString(
+				fmt.Sprintf("* [%s.%s.%s]: Coverage for this PR is %f%%, which does not meet the coverage target of %f%% (base PR has %f%% coverage)\n",
+					entry.Feature, entry.Stage, entry.Label, entry.Actual, entry.Target, entry.Base))
+		}
+		return b.String()
 	}
 	return "An internal error occurred while computing coverage. Please file an issue for investigation."
 }

--- a/policybot/pkg/coverage/diff.go
+++ b/policybot/pkg/coverage/diff.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/google/go-github/v26/github"
+
 	"istio.io/bots/policybot/pkg/storage"
 )
 

--- a/policybot/pkg/coverage/diff_test.go
+++ b/policybot/pkg/coverage/diff_test.go
@@ -1,0 +1,164 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package coverage
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"istio.io/bots/policybot/pkg/storage"
+)
+
+var (
+	config = Config{
+		"all": &Feature{
+			Stages: map[string]*Stage{
+				"stable": &Stage{
+					Packages: []string{"istio.io/bots/policybot"},
+					Targets: map[string]float64{
+						"unit": 70,
+					},
+				},
+			},
+		},
+	}
+)
+
+func coverage(label string, covered int64) *storage.CoverageData {
+	return &storage.CoverageData{
+		PackageName:  "istio.io/bots/policybot/pkg/coverage",
+		StmtsCovered: covered,
+		StmtsTotal:   100,
+		Type:         label,
+	}
+}
+
+func TestComputeDiffResult(t *testing.T) {
+	tests := []struct {
+		name             string
+		cfg              Config
+		baseCov, headCov map[string][]*storage.CoverageData
+		expected         *DiffResult
+	}{
+		{
+			name: "base",
+			cfg:  config,
+			baseCov: map[string][]*storage.CoverageData{
+				"istio.io/bots/policybot/pkg/coverage": {coverage("unit", 1)},
+			},
+			headCov: map[string][]*storage.CoverageData{
+				"istio.io/bots/policybot/pkg/coverage": {coverage("unit", 70)},
+			},
+			expected: &DiffResult{},
+		},
+		{
+			name: "failure",
+			cfg:  config,
+			baseCov: map[string][]*storage.CoverageData{
+				"istio.io/bots/policybot/pkg/coverage": {coverage("unit", 1)},
+			},
+			headCov: map[string][]*storage.CoverageData{
+				"istio.io/bots/policybot/pkg/coverage": {coverage("unit", 1)},
+			},
+			expected: &DiffResult{
+				Entries: []*DiffResultEntry{
+					&DiffResultEntry{
+						Feature: "all",
+						Stage:   "stable",
+						Label:   "unit",
+						Target:  70,
+						Actual:  1,
+						Base:    1,
+					},
+				},
+			},
+		},
+		{
+			name: "ignoreLabel",
+			cfg:  config,
+			baseCov: map[string][]*storage.CoverageData{
+				"istio.io/bots/policybot/pkg/coverage": {
+					coverage("unit", 1), coverage("e2e", 100),
+				},
+			},
+			headCov: map[string][]*storage.CoverageData{
+				"istio.io/bots/policybot/pkg/coverage": {
+					coverage("unit", 1), coverage("e2e", 100),
+				},
+			},
+			expected: &DiffResult{
+				Entries: []*DiffResultEntry{
+					&DiffResultEntry{
+						Feature: "all",
+						Stage:   "stable",
+						Label:   "unit",
+						Target:  70,
+						Actual:  1,
+						Base:    1,
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		actual := computeDiffResult(test.cfg, test.baseCov, test.headCov)
+		if !reflect.DeepEqual(actual, test.expected) {
+			t.Errorf("[%s]: expected %+v but got %+v", test.name, test.expected, actual)
+			t.Errorf("Actual entries:")
+			for _, e := range actual.Entries {
+				t.Errorf("\t%+v", *e)
+			}
+			t.Errorf("Expected entries:")
+			for _, e := range test.expected.Entries {
+				t.Errorf("\t%+v", *e)
+			}
+		}
+	}
+}
+
+func TestDiffResultGithubStatus(t *testing.T) {
+	tests := []struct {
+		diffResult DiffResult
+		expected   string
+	}{
+		{
+			DiffResult{},
+			Success,
+		},
+		{
+			DiffResult{
+				err: errors.New(""),
+			},
+			Error,
+		},
+		{
+			DiffResult{
+				Entries: []*DiffResultEntry{
+					&DiffResultEntry{},
+				},
+			},
+			Failure,
+		},
+	}
+
+	for _, test := range tests {
+		actual := test.diffResult.GetGithubStatus()
+		if actual != test.expected {
+			t.Errorf("[%+v] expected status %s but got %s", test.diffResult, test.expected, actual)
+		}
+	}
+}

--- a/policybot/pkg/coverage/diff_test.go
+++ b/policybot/pkg/coverage/diff_test.go
@@ -26,7 +26,7 @@ var (
 	config = Config{
 		"all": &Feature{
 			Stages: map[string]*Stage{
-				"stable": &Stage{
+				"stable": {
 					Packages: []string{"istio.io/bots/policybot"},
 					Targets: map[string]float64{
 						"unit": 70,
@@ -75,7 +75,7 @@ func TestComputeDiffResult(t *testing.T) {
 			},
 			expected: &DiffResult{
 				Entries: []*DiffResultEntry{
-					&DiffResultEntry{
+					{
 						Feature: "all",
 						Stage:   "stable",
 						Label:   "unit",
@@ -101,7 +101,7 @@ func TestComputeDiffResult(t *testing.T) {
 			},
 			expected: &DiffResult{
 				Entries: []*DiffResultEntry{
-					&DiffResultEntry{
+					{
 						Feature: "all",
 						Stage:   "stable",
 						Label:   "unit",
@@ -148,7 +148,7 @@ func TestDiffResultGithubStatus(t *testing.T) {
 		{
 			DiffResult{
 				Entries: []*DiffResultEntry{
-					&DiffResultEntry{},
+					{},
 				},
 			},
 			Failure,


### PR DESCRIPTION
This PR adds logic to check coverage targets. Currently base coverage data isn't used except for generating a Github comment. This PR also slightly changes how coverage data is stored in Spanner. Because we define some test targets as an aggregate of multiple test types, we need to generate those when coverage files are converted to Spanner rows, since once we do the conversion, it's not possible to merge two different test types.