### PR TITLE
Bunch of bot improvements

### DIFF
--- a/policybot/Makefile
+++ b/policybot/Makefile
@@ -5,7 +5,7 @@ HUB ?= gcr.io/istio-testing/policybot
 IMG := $(HUB):$(TAG)
 export GO111MODULE=on
 
-dockerrun := docker run -t -i --sig-proxy=true --rm -v $(shell pwd):/site -w /site "gcr.io/istio-testing/build-tools:2019-08-29T13-57-48"
+dockerrun := docker run -t -i --sig-proxy=true --rm -v $(shell pwd):/site -w /site "gcr.io/istio-testing/build-tools:2019-10-11T13-37-52"
 
 gen:
 	@$(dockerrun) scripts/gen_dashboard.sh

--- a/policybot/cmd/server.go
+++ b/policybot/cmd/server.go
@@ -29,6 +29,7 @@ import (
 	"istio.io/bots/policybot/dashboard"
 	"istio.io/bots/policybot/handlers/githubwebhook"
 	"istio.io/bots/policybot/handlers/githubwebhook/filters"
+	"istio.io/bots/policybot/handlers/githubwebhook/filters/boilerplatecleaner"
 	"istio.io/bots/policybot/handlers/githubwebhook/filters/cfgmonitor"
 	"istio.io/bots/policybot/handlers/githubwebhook/filters/labeler"
 	"istio.io/bots/policybot/handlers/githubwebhook/filters/nagger"
@@ -220,6 +221,11 @@ func runWithConfig(a *config.Args) error {
 		return fmt.Errorf("unable to create labeler: %v", err)
 	}
 
+	cleaner, err := boilerplatecleaner.NewCleaner(gc, cache, a.Orgs, a.BoilerplatesToClean)
+	if err != nil {
+		return fmt.Errorf("unable to create boilerplate cleaner: %v", err)
+	}
+
 	unstaler, err := unstaler.NewUnstaler(gc, a.Orgs)
 	if err != nil {
 		return fmt.Errorf("unable to create unstaler: %v", err)
@@ -255,6 +261,7 @@ func runWithConfig(a *config.Args) error {
 		nag,
 		unstaler,
 		labeler,
+		cleaner,
 		monitor,
 	}
 

--- a/policybot/dashboard/dashboard.go
+++ b/policybot/dashboard/dashboard.go
@@ -133,9 +133,6 @@ func New(router *mux.Router, store storage.Store, cache *cache.Cache, a *config.
 		addEntry("Recently Inactive", "Maintainers that have not recently contributed to the project.").
 		addPageWithQuery("/maintainers", "filter", "inactive", maintainers.RenderList).
 		endEntry().
-		addEntry("Emeritus", "Maintainers that are no longer  involved with the project.").
-		addPageWithQuery("/maintainers", "filter", "emeritus", maintainers.RenderList).
-		endEntry().
 		addPage("/maintainers", maintainers.RenderList).
 		addPage("/maintainers/{login}", maintainers.RenderSingle).
 		endEntry()

--- a/policybot/handlers/githubwebhook/filters/boilerplatecleaner/cleaner.go
+++ b/policybot/handlers/githubwebhook/filters/boilerplatecleaner/cleaner.go
@@ -1,0 +1,209 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package boilerplatecleaner
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/google/go-github/v26/github"
+
+	"istio.io/bots/policybot/handlers/githubwebhook/filters"
+	"istio.io/bots/policybot/pkg/config"
+	"istio.io/bots/policybot/pkg/gh"
+	"istio.io/bots/policybot/pkg/storage"
+	"istio.io/bots/policybot/pkg/storage/cache"
+	"istio.io/pkg/log"
+)
+
+// Removes redundant boilerplate content from PRs and issues
+type Cleaner struct {
+	cache            *cache.Cache
+	gc               *gh.ThrottledClient
+	orgs             []config.Org
+	boilerplates     []config.Boilerplate
+	multiLineRegexes map[string]*regexp.Regexp
+	repos            map[string][]config.Boilerplate // index is org/repo, value is org-level boilerplate
+}
+
+var scope = log.RegisterScope("cleaner", "Issue and PR boilerplate cleaner", 0)
+
+func NewCleaner(gc *gh.ThrottledClient, cache *cache.Cache, orgs []config.Org, boilerplates []config.Boilerplate) (filters.Filter, error) {
+	l := &Cleaner{
+		cache:            cache,
+		gc:               gc,
+		orgs:             orgs,
+		boilerplates:     boilerplates,
+		multiLineRegexes: make(map[string]*regexp.Regexp),
+		repos:            make(map[string][]config.Boilerplate),
+	}
+
+	for _, al := range boilerplates {
+		if err := l.processBoilerplateRegexes(al); err != nil {
+			return nil, err
+		}
+	}
+
+	for _, org := range orgs {
+		for _, al := range org.BoilerplatesToClean {
+			if err := l.processBoilerplateRegexes(al); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	for _, org := range orgs {
+		for _, repo := range org.Repos {
+			l.repos[org.Name+"/"+repo.Name] = org.BoilerplatesToClean
+		}
+	}
+
+	return l, nil
+}
+
+// Precompile all the regexes
+func (l *Cleaner) processBoilerplateRegexes(b config.Boilerplate) error {
+	scope.Infof("REGEX STRING: %s", b.Regex)
+	scope.Infof("REGEX BYTES: %v", []byte(b.Regex))
+
+	r, err := regexp.Compile("(?mis)" + b.Regex)
+	if err != nil {
+		return fmt.Errorf("invalid regular expression %s: %v", b.Regex, err)
+	}
+	l.multiLineRegexes[b.Regex] = r
+
+	return nil
+}
+
+// process an event arriving from GitHub
+func (l *Cleaner) Handle(context context.Context, event interface{}) {
+	action := ""
+	repo := ""
+	number := 0
+	var issue *storage.Issue
+	var pr *storage.PullRequest
+
+	switch p := event.(type) {
+	case *github.IssuesEvent:
+		scope.Infof("Received IssuesEvent: %s, %d, %s", p.GetRepo().GetFullName(), p.GetIssue().GetNumber(), p.GetAction())
+
+		action = p.GetAction()
+		repo = p.GetRepo().GetFullName()
+		number = p.GetIssue().GetNumber()
+		issue = gh.ConvertIssue(
+			p.GetRepo().GetOwner().GetLogin(),
+			p.GetRepo().GetName(),
+			p.GetIssue())
+
+	case *github.PullRequestEvent:
+		scope.Infof("Received PullRequestEvent: %s, %d, %s", p.GetRepo().GetFullName(), p.GetPullRequest().GetNumber(), p.GetAction())
+
+		action = p.GetAction()
+		repo = p.GetRepo().GetFullName()
+		number = p.GetPullRequest().GetNumber()
+		pr = gh.ConvertPullRequest(
+			p.GetRepo().GetOwner().GetLogin(),
+			p.GetRepo().GetName(),
+			p.GetPullRequest(),
+			nil)
+
+	default:
+		// not what we're looking for
+		scope.Debugf("Unknown event received: %T %+v", p, p)
+		return
+	}
+
+	if action != "opened" {
+		// not what we care about
+		scope.Infof("Ignoring event for issue/PR %d from repo %s since it doesn't have a supported action: %s", number, repo, action)
+		return
+	}
+
+	// see if the event is in a repo we're monitoring
+	boilerplates, ok := l.repos[repo]
+	if !ok {
+		scope.Infof("Ignoring event for issue/PR %d from repo %s since it's not in a monitored repo", number, repo)
+		return
+	}
+
+	scope.Infof("Processing event for issue/PR %d from repo %s, %s", number, repo, action)
+
+	if issue != nil {
+		l.processIssue(context, issue, boilerplates)
+	} else {
+		l.processPullRequest(context, pr, boilerplates)
+	}
+}
+
+func (l *Cleaner) processIssue(context context.Context, issue *storage.Issue, orgBoilerplates []config.Boilerplate) {
+	original := strings.ReplaceAll(issue.Body, "\r\n", "\n")
+	body := original
+
+	for _, b := range orgBoilerplates {
+		r := l.multiLineRegexes[b.Regex]
+		body = r.ReplaceAllString(body, b.Replacement)
+	}
+
+	for _, b := range l.boilerplates {
+		r := l.multiLineRegexes[b.Regex]
+		body = r.ReplaceAllString(body, b.Replacement)
+	}
+
+	if body != original {
+		ir := &github.IssueRequest{Body: &body}
+		if _, _, err := l.gc.ThrottledCall(func(client *github.Client) (interface{}, *github.Response, error) {
+			return client.Issues.Edit(context, issue.OrgLogin, issue.RepoName, int(issue.IssueNumber), ir)
+		}); err != nil {
+			scope.Errorf("Unable to remove boilerplate from comment on PR %d in repo %s/%s: %v", issue.IssueNumber, issue.OrgLogin, issue.RepoName, err)
+			return
+		}
+		scope.Infof("Removed boilerplate from PR %d in repo %s/%s", issue.IssueNumber, issue.OrgLogin, issue.RepoName)
+	} else {
+		scope.Infof("No boilerplate to remove from PR %d in repo %s/%s", issue.IssueNumber, issue.OrgLogin, issue.RepoName)
+	}
+}
+
+func (l *Cleaner) processPullRequest(context context.Context, pr *storage.PullRequest, orgBoilerplates []config.Boilerplate) {
+	body := pr.Body
+
+	scope.Infof("original body: %v", []byte(body))
+
+	for _, b := range orgBoilerplates {
+		r := l.multiLineRegexes[b.Regex]
+		body = r.ReplaceAllString(body, b.Replacement)
+		fmt.Printf("rep body: %v", []byte(body))
+	}
+
+	for _, b := range l.boilerplates {
+		r := l.multiLineRegexes[b.Regex]
+		body = r.ReplaceAllString(body, b.Replacement)
+		fmt.Printf("rep body: %v", []byte(body))
+	}
+
+	if body != pr.Body {
+		ir := &github.IssueRequest{Body: &body}
+		if _, _, err := l.gc.ThrottledCall(func(client *github.Client) (interface{}, *github.Response, error) {
+			return client.Issues.Edit(context, pr.OrgLogin, pr.RepoName, int(pr.PullRequestNumber), ir)
+		}); err != nil {
+			scope.Errorf("Unable to remove boilerplate from comment on PR %d in repo %s/%s: %v", pr.PullRequestNumber, pr.OrgLogin, pr.RepoName, err)
+			return
+		}
+		scope.Infof("Removed boilerplate from PR %d in repo %s/%s", pr.PullRequestNumber, pr.OrgLogin, pr.RepoName)
+	} else {
+		scope.Infof("No boilerplate to remove from PR %d in repo %s/%s", pr.PullRequestNumber, pr.OrgLogin, pr.RepoName)
+	}
+}

--- a/policybot/handlers/githubwebhook/filters/refresher/refresher.go
+++ b/policybot/handlers/githubwebhook/filters/refresher/refresher.go
@@ -16,7 +16,6 @@ package refresher
 
 import (
 	"context"
-	"time"
 
 	"github.com/google/go-github/v26/github"
 
@@ -80,7 +79,7 @@ func (r *Refresher) Handle(context context.Context, event interface{}) {
 			OrgLogin:    issue.OrgLogin,
 			RepoName:    issue.RepoName,
 			IssueNumber: issue.IssueNumber,
-			CreatedAt:   time.Now(),
+			CreatedAt:   p.GetIssue().GetUpdatedAt(),
 			Actor:       p.GetSender().GetLogin(),
 			Action:      p.GetAction(),
 		}
@@ -118,7 +117,7 @@ func (r *Refresher) Handle(context context.Context, event interface{}) {
 			RepoName:       issueComment.RepoName,
 			IssueNumber:    issueComment.IssueNumber,
 			IssueCommentID: p.GetComment().GetID(),
-			CreatedAt:      time.Now(),
+			CreatedAt:      p.GetComment().GetUpdatedAt(),
 			Actor:          p.GetSender().GetLogin(),
 			Action:         p.GetAction(),
 		}
@@ -188,9 +187,10 @@ func (r *Refresher) Handle(context context.Context, event interface{}) {
 			OrgLogin:          p.GetOrganization().GetLogin(),
 			RepoName:          p.GetRepo().GetName(),
 			PullRequestNumber: int64(p.GetPullRequest().GetNumber()),
-			CreatedAt:         time.Now(),
+			CreatedAt:         p.GetPullRequest().GetUpdatedAt(),
 			Actor:             p.GetSender().GetLogin(),
 			Action:            p.GetAction(),
+			Merged:            p.GetPullRequest().GetMerged(),
 		}
 
 		events := []*storage.PullRequestEvent{event}
@@ -225,7 +225,7 @@ func (r *Refresher) Handle(context context.Context, event interface{}) {
 			RepoName:            review.RepoName,
 			PullRequestNumber:   review.PullRequestNumber,
 			PullRequestReviewID: p.GetReview().GetID(),
-			CreatedAt:           time.Now(),
+			CreatedAt:           p.GetReview().GetSubmittedAt(),
 			Actor:               p.GetSender().GetLogin(),
 			Action:              p.GetAction(),
 		}
@@ -262,7 +262,7 @@ func (r *Refresher) Handle(context context.Context, event interface{}) {
 			RepoName:                   comment.RepoName,
 			PullRequestNumber:          comment.PullRequestNumber,
 			PullRequestReviewCommentID: p.GetComment().GetID(),
-			CreatedAt:                  time.Now(),
+			CreatedAt:                  p.GetComment().GetUpdatedAt(),
 			Actor:                      p.GetSender().GetLogin(),
 			Action:                     p.GetAction(),
 		}
@@ -296,7 +296,7 @@ func (r *Refresher) Handle(context context.Context, event interface{}) {
 			OrgLogin:      comment.OrgLogin,
 			RepoName:      comment.RepoName,
 			RepoCommentID: p.GetComment().GetID(),
-			CreatedAt:     time.Now(),
+			CreatedAt:     p.GetComment().GetUpdatedAt(),
 			Actor:         p.GetSender().GetLogin(),
 			Action:        p.GetAction(),
 		}

--- a/policybot/pkg/config/args.go
+++ b/policybot/pkg/config/args.go
@@ -155,6 +155,11 @@ type Milestone struct {
 	Closed      bool      `json:"closed"`
 }
 
+type Boilerplate struct {
+	Regex       string
+	Replacement string
+}
+
 // Configuration for an individual repo.
 type Repo struct {
 	// Name of the repo
@@ -187,6 +192,9 @@ type Org struct {
 	// Milestones to create in all repos being controlled in this organization
 	MilestonesToCreate []Milestone `json:"milestones_to_create"`
 
+	// PR or issue boilerplate to remove in all repos being controlled in this organization
+	BoilerplatesToClean []Boilerplate `json:"boilerplates_to_clean"`
+
 	// BucketName to locate prow test output
 	BucketName string `json:"bucket_name"`
 
@@ -216,6 +224,9 @@ type Args struct {
 
 	// Global auto-labeling
 	AutoLabels []AutoLabel `json:"autolabels"`
+
+	// Global PR or issue boilerplate to remove
+	BoilerplatesToClean []Boilerplate `json:"boilerplates_to_clean"`
 
 	// Name to use as sender when sending emails
 	EmailFrom string `json:"email_from"`

--- a/policybot/pkg/gh/convert.go
+++ b/policybot/pkg/gh/convert.go
@@ -164,6 +164,7 @@ func ConvertPullRequest(orgLogin string, repoName string, pr *github.PullRequest
 		Author:             pr.GetUser().GetLogin(),
 		HeadCommit:         sha,
 		BranchName:         branch,
+		Merged:             pr.GetMerged(),
 	}
 }
 

--- a/policybot/pkg/storage/spanner/query.go
+++ b/policybot/pkg/storage/spanner/query.go
@@ -729,3 +729,19 @@ func (s *store) getPRActivity(context context.Context, orgLogin string, repoName
 
 	return err
 }
+
+func (s store) QueryAllUserAffiliations(context context.Context, cb func(affiliation *storage.UserAffiliation) error) error {
+	sql := `SELECT * from UserAffiliation WHERE true`
+	stmt := spanner.NewStatement(sql)
+	iter := s.client.Single().Query(context, stmt)
+	err := iter.Do(func(row *spanner.Row) error {
+		affiliation := &storage.UserAffiliation{}
+		if err := rowToStruct(row, affiliation); err != nil {
+			return err
+		}
+
+		return cb(affiliation)
+	})
+
+	return err
+}

--- a/policybot/pkg/storage/store.go
+++ b/policybot/pkg/storage/store.go
@@ -77,6 +77,7 @@ type Store interface {
 	QueryTestResultByTestName(context context.Context, orgLogin string, repoName string, testName string, cb func(*TestResult) error) error
 	QueryTestResultsBySHA(context context.Context, orgLogin string, repoName string, sha string, cb func(*TestResult) error) error
 	QueryCoverageDataBySHA(context context.Context, orgLogin string, repoName string, sha string, cb func(*CoverageData) error) error
+	QueryAllUserAffiliations(context context.Context, cb func(affiliation *UserAffiliation) error) error
 
 	// TODO: needs to be org-specific and/or repo-specific, needs to use a callback instead of returning a slice
 	QueryTestFlakeIssues(context context.Context, inactiveDays, createdDays int) ([]*Issue, error)

--- a/policybot/pkg/storage/types.go
+++ b/policybot/pkg/storage/types.go
@@ -102,6 +102,7 @@ type PullRequest struct {
 	State              string
 	BranchName         string
 	HeadCommit         string
+	Merged             bool
 }
 
 type PullRequestReviewComment struct {
@@ -233,6 +234,7 @@ type PullRequestEvent struct {
 	CreatedAt         time.Time
 	Actor             string
 	Action            string
+	Merged            bool
 }
 
 type PullRequestReviewCommentEvent struct {

--- a/policybot/pkg/syncer/syncer.go
+++ b/policybot/pkg/syncer/syncer.go
@@ -880,26 +880,66 @@ func (ss *syncState) handleCODEOWNERS(org *config.Org, repo *config.Repo, mainta
 			login = strings.TrimPrefix(login, "@")
 			login = strings.TrimSuffix(login, ",")
 
-			// add the path to this maintainer's list
-			path := strings.TrimPrefix(fields[0], "/")
-			path = strings.TrimSuffix(path, "/*")
-			if path == "*" {
-				path = ""
+			names, err := ss.expandTeam(org, login)
+			if err != nil {
+				return err
 			}
 
-			scope.Debugf("User '%s' can review path '%s/%s/%s'", login, org.Name, repo.Name, path)
+			for _, name := range names {
 
-			maintainer, err := ss.getMaintainer(org, maintainers, login)
-			if maintainer == nil || err != nil {
-				scope.Warnf("Couldn't get info on potential maintainer %s: %v", login, err)
-				continue
+				// add the path to this maintainer's list
+				path := strings.TrimPrefix(fields[0], "/")
+				path = strings.TrimSuffix(path, "/*")
+				if path == "*" {
+					path = ""
+				}
+
+				scope.Debugf("User '%s' can review path '%s/%s/%s'", name, org.Name, repo.Name, path)
+
+				maintainer, err := ss.getMaintainer(org, maintainers, name)
+				if maintainer == nil || err != nil {
+					scope.Warnf("Couldn't get info on potential maintainer %s: %v", name, err)
+					continue
+				}
+
+				maintainer.Paths = append(maintainer.Paths, repo.Name+"/"+path)
 			}
-
-			maintainer.Paths = append(maintainer.Paths, repo.Name+"/"+path)
 		}
 	}
 
 	return nil
+}
+
+func (ss *syncState) expandTeam(org *config.Org, login string) ([]string, error) {
+	index := strings.Index(login, "/")
+	if index < 0 {
+		return []string{login}, nil
+	}
+
+	team, _, err := ss.syncer.gc.ThrottledCall(func(client *github.Client) (interface{}, *github.Response, error) {
+		return client.Teams.GetTeamBySlug(ss.ctx, org.Name, login[index+1:])
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("unable to get information on team %s: %v", login, err)
+	}
+
+	id := team.(*github.Team).GetID()
+
+	ghUsers, _, err := ss.syncer.gc.ThrottledCall(func(client *github.Client) (interface{}, *github.Response, error) {
+		return client.Teams.ListTeamMembers(ss.ctx, id, nil)
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("unable to get members of team %s: %v", login, err)
+	}
+
+	var users []string
+	for _, u := range ghUsers.([]*github.User) {
+		users = append(users, u.GetLogin())
+	}
+
+	return users, nil
 }
 
 type ownersFile struct {

--- a/policybot/policybot.yaml
+++ b/policybot/policybot.yaml
@@ -106,6 +106,68 @@ autolabels:
     labelstoapply:
       - kind/enhancement
 
+boilerplates_to_clean:
+  - regex: |
+      (.*)Please provide a description for what this PR is for.
+
+      (.*)And to help us figure out who should review this PR, please
+      put an X in all the areas that this PR affects.
+
+      (.*)\[.*\] +Configuration Infrastructure
+      \[.*\] +Docs
+      \[.*\] +Installation
+      \[.*\] +Networking
+      \[.*\] +Performance and Scalability
+      \[.*\] +Policies and Telemetry
+      \[.*\] +Security
+      \[.*\] +Test and Release
+      \[.*\] +User Experience
+      \[.*\] +Developer Infrastructure
+      (.*)
+    replacement: $1$2$3$4
+
+  - regex: |
+      (.*)\(NOTE: This is used to report product bugs:
+        To report a security vulnerability, please visit <https://istio.io/about/security-vulnerabilities/>
+        To ask questions about how to use Istio, please visit <https://discuss.istio.io>
+      \)
+
+      (.*)\*\*Affected product area \(please put an X in all that apply\)\*\*
+
+      (.*)\[.*\] +Configuration Infrastructure
+      \[.*\] +Docs
+      \[.*\] +Installation
+      \[.*\] +Networking
+      \[.*\] +Performance and Scalability
+      \[.*\] +Policies and Telemetry
+      \[.*\] +Security
+      \[.*\] +Test and Release
+      \[.*\] +User Experience
+      \[.*\] +Developer Infrastructure
+
+      (.*)Additionally, please consider attaching a \[cluster state archive\]\(http://istio.io/help/bugs/#generating-a-cluster-state-archive\) by attaching
+      the dump file to this issue.
+      (.*)
+    replacement: $1$2$3$4$5
+
+  - regex: |
+      (.*)\(This is used to request new product features, please visit <https://discuss.istio.io> for questions on using Istio\)
+
+      (.*)\*\*Affected product area \(please put an X in all that apply\)\*\*
+
+      (.*)\[.*\] +Configuration Infrastructure
+      \[.*\] +Docs
+      \[.*\] +Installation
+      \[.*\] +Networking
+      \[.*\] +Performance and Scalability
+      \[.*\] +Policies and Telemetry
+      \[.*\] +Security
+      \[.*\] +Test and Release
+      \[.*\] +User Experience
+      \[.*\] +Developer Infrastructure
+      (.*)
+    replacement: $1$2$3$4
+
 orgs:
   - name: istio
     bucket_name: istio-prow

--- a/policybot/policybot.yaml
+++ b/policybot/policybot.yaml
@@ -122,7 +122,7 @@ orgs:
 
       - name: "1.3"
         due_date: 2019-09-11T00:00:00Z
-        closed: false
+        closed: true
 
       - name: "1.2"
         date: 2019-06-20T00:00:00Z
@@ -193,6 +193,10 @@ orgs:
         color: ff0000
         description: Set this label on a PR to auto-merge it to the release-1.3 branch
 
+      - name: cherrypick/release-1.4
+        color: ff0000
+        description: Set this label on a PR to auto-merge it to the release-1.4 branch
+
       - name: 'cla: yes'
         color: bfdadc
         description: Set by the Google CLA bot to indicate the author of a PR has signed the Google CLA.
@@ -210,6 +214,9 @@ orgs:
         description: Indicates a PR needs to be rebased before being merged
 
     repos:
+      - name: proxy
+      - name: istio
+      - name: release-builder
       - name: client-go
       - name: tests
       - name: gogo-genproto
@@ -224,5 +231,3 @@ orgs:
       - name: pkg
       - name: bots
       - name: common-files
-      - name: istio
-      - name: proxy

--- a/policybot/spanner.ddl
+++ b/policybot/spanner.ddl
@@ -125,6 +125,7 @@ CREATE TABLE PullRequestEvents (
   CreatedAt TIMESTAMP NOT NULL,
   Action STRING(MAX) NOT NULL,
   Actor STRING(MAX) NOT NULL,
+  Merged BOOL NOT NULL,
 ) PRIMARY KEY(OrgLogin, RepoName, PullRequestNumber, CreatedAt),
   INTERLEAVE IN PARENT Repos ON DELETE CASCADE;
 
@@ -192,6 +193,7 @@ CREATE TABLE PullRequests (
   Body STRING(MAX) NOT NULL,
   HeadCommit STRING(MAX) NOT NULL,
   BranchName STRING(MAX) NOT NULL,
+  Merged BOOL NOT NULL,
 ) PRIMARY KEY(OrgLogin, RepoName, PullRequestNumber),
   INTERLEAVE IN PARENT Repos ON DELETE CASCADE;
 

--- a/policybot/userdata.yaml
+++ b/policybot/userdata.yaml
@@ -1,5 +1,725 @@
 users:
-  - github_login: geeknoid
-    affiliations:
-      - organization: Google
-        start: 2014-11-14
+  - affiliations:
+      - end: "9999-01-01"
+        organization: IBM
+        start: "2013-06-03"
+    email_addresses:
+      - gihanson@us.ibm.com
+    github_login: GregHanson
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Google
+        start: "2014-03-24"
+    email_addresses:
+      - yinjie@google.com
+    github_login: JimmyCYJ
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Google
+        start: "2015-07-13"
+    email_addresses:
+      - piotrsikora@google.com
+    github_login: PiotrSikora
+  - affiliations:
+      - end: "2018-04-15"
+        organization: Google
+        start: "2013-06-03"
+      - end: "9999-01-01"
+        organization: Tetrate
+        start: "2018-04-15"
+    github_login: ZackButcher
+  - affiliations:
+      - end: "9999-01-01"
+        organization: IBM
+        start: "2011-09-01"
+    github_login: aal80
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Google
+        start: "2017-02-03"
+    email_addresses:
+      - andracis@google.com
+    github_login: andraxylia
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Google
+        start: "2015-09-14"
+    email_addresses:
+      - jasonyoung@google.com
+    github_login: ayj
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Google
+        start: "2016-03-07"
+    email_addresses:
+      - bianpengyuan@google.com
+    github_login: bianpengyuan
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Google
+        start: "2019-07-29"
+    github_login: carolynhu
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Google
+        start: "2013-06-03"
+    github_login: chxchx
+  - affiliations:
+      - end: "9999-01-01"
+        organization: IBM
+        start: "2013-06-03"
+    email_addresses:
+      - clyang@cn.ibm.com
+    github_login: clyang82
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Google
+        start: "2013-06-03"
+    email_addresses:
+      - costin@google.com
+    github_login: costinm
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Google
+        start: "2018-11-12"
+    github_login: davidebbo
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Google
+        start: "2013-06-03"
+    email_addresses:
+      - diemvu@google.com
+    github_login: diemtvu
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Google
+        start: "2019-01-07"
+    github_login: djazayeri
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Google
+        start: "2013-06-03"
+    email_addresses:
+      - dougreid@google.com
+    github_login: douglas-reid
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Google
+        start: "2018-07-01"
+    email_addresses:
+      - jblatt@google.com
+    github_login: duderino
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Google
+        start: "2019-07-18"
+    github_login: elfinhe
+  - affiliations:
+      - end: "9999-01-01"
+        organization: IBM
+        start: "2019-01-01"
+    email_addresses:
+      - ericvn@us.ibm.com
+    github_login: ericvn
+  - affiliations:
+      - end: "9999-01-01"
+        organization: IBM
+        start: "1997-04-01"
+    email_addresses:
+      - snible@us.ibm.com
+    github_login: esnible
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Google
+        start: "2013-06-03"
+    email_addresses:
+      - fejta@google.com
+    github_login: fejta
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Huawei
+        start: "2013-06-03"
+    email_addresses:
+      - dustise@live.com
+    github_login: fleeto
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Google
+        start: "2013-06-03"
+    email_addresses:
+      - fpesce@google.com
+    github_login: fpesce
+  - affiliations:
+      - end: "9999-01-01"
+        organization: IBM
+        start: "2013-06-03"
+    email_addresses:
+      - frankb@ca.ibm.com
+    github_login: frankbu
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Google
+        start: "2016-01-25"
+    email_addresses:
+      - gargnupur@google.com
+    github_login: gargnupur
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Google
+        start: "2014-11-14"
+    email_addresses:
+      - mtail@google.com
+    github_login: geeknoid
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Google
+        start: "2013-06-03"
+    github_login: guptasu
+  - affiliations:
+      - end: "9999-01-01"
+        organization: IBM
+        start: "2013-06-03"
+    email_addresses:
+      - liugya@cn.ibm.com
+    github_login: gyliu513
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Google
+        start: "2013-06-03"
+    email_addresses:
+      - hklai@google.com
+    github_login: hklai
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Google
+        start: "2013-06-03"
+    email_addresses:
+      - howardjohn@google.com
+    github_login: howardjohn
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Huawei
+        start: "2013-06-03"
+    email_addresses:
+      - xuzhonghu@huawei.com
+    github_login: hzxuzhonghu
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Google
+        start: "2013-06-03"
+    email_addresses:
+      - angwar@google.com
+    github_login: icygalz
+  - affiliations:
+      - end: "9999-01-01"
+        organization: IBM
+        start: "2013-06-03"
+    email_addresses:
+      - ijsnellf@us.ibm.com
+    github_login: ijsnellf
+  - affiliations:
+      - end: "9999-01-01"
+        organization: ignore
+        start: "2013-06-03"
+    github_login: imgbot[bot]
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Google
+        start: "2013-06-03"
+    email_addresses:
+      - jianfeih@google.com
+    github_login: incfly
+  - affiliations:
+      - end: "9999-01-01"
+        organization: IBM
+        start: "2013-06-03"
+    email_addresses:
+      - irisdingbj@gmail.com
+    github_login: irisdingbj
+  - affiliations:
+      - end: "9999-01-01"
+        organization: ignore
+        start: "2013-06-03"
+    github_login: istio-testing
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Google
+        start: "2013-06-03"
+    email_addresses:
+      - jasonwzm@google.com
+    github_login: jasonwzm
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Google
+        start: "2013-06-03"
+    email_addresses:
+      - jeffmendoza@google.com
+    github_login: jeffmendoza
+  - affiliations:
+      - end: "9999-01-01"
+        organization: IBM
+        start: "1990-10-01"
+    email_addresses:
+      - jnativio@us.ibm.com
+    github_login: jnativio
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Cisco
+        start: "2013-06-03"
+    email_addresses:
+      - joycej@cisco.com
+    github_login: john-a-joyce
+  - affiliations:
+      - end: "9999-01-01"
+        organization: IBM
+        start: "2006-06-05"
+    github_login: johnma14
+  - affiliations:
+      - end: "9999-01-01"
+        organization: RedHat
+        start: "2015-12-07"
+    github_login: jwendell
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Google
+        start: "2016-06-01"
+    email_addresses:
+      - kuat@google.com
+    github_login: kyessenov
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Google
+        start: "2013-06-03"
+    github_login: ldemailly
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Google
+        start: "2013-06-03"
+    email_addresses:
+      - leitang@google.com
+    github_login: lei-tang
+  - affiliations:
+      - end: "2018-11-14"
+        organization: IBM
+        start: "2013-06-03"
+      - end: "9999-01-01"
+        organization: Tetrate
+        start: "2018-11-15"
+    email_addresses:
+      - liam@tetrate.io
+    github_login: liamawhite
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Huawei
+        start: "2013-06-03"
+    github_login: lichuqiang
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Google
+        start: "2013-06-03"
+    email_addresses:
+      - liminwang@google.com
+    github_login: liminw
+  - affiliations:
+      - end: "9999-01-01"
+        organization: IBM
+        start: "2013-06-03"
+    email_addresses:
+      - linsun@us.ibm.com
+    github_login: linsun
+  - affiliations:
+      - end: "2018-09-15"
+        organization: Google
+        start: "2013-06-03"
+      - end: "9999-01-01"
+        organization: Tetrate
+        start: "2018-09-15"
+    email_addresses:
+      - lizan@tetrate.io
+    github_login: lizan
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Google
+        start: "2007-05-17"
+    email_addresses:
+      - lryan@google.com
+    github_login: louiscryan
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Huawei
+        start: "2013-06-03"
+    email_addresses:
+      - 1045438139@qq.com
+    github_login: loverto
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Google
+        start: "2013-06-03"
+    email_addresses:
+      - mjog@google.com
+    github_login: mandarjog
+  - affiliations:
+      - end: "9999-01-01"
+        organization: IBM
+        start: "2000-12-01"
+    github_login: mbanikazemi
+  - affiliations:
+      - end: "9999-01-01"
+        organization: ignore
+        start: "2013-06-03"
+    github_login: mergify[bot]
+  - affiliations:
+      - end: "9999-01-01"
+        organization: IBM
+        start: "2013-06-03"
+    email_addresses:
+      - llcao@cn.ibm.com
+    github_login: morvencao
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Google
+        start: "2013-06-03"
+    email_addresses:
+      - yonggangl@google.com
+    github_login: myidpt
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Google
+        start: "2017-03-06"
+    github_login: navinger
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Google
+        start: "2017-02-03"
+    email_addresses:
+      - nathanmittler@google.com
+    github_login: nmittler
+  - affiliations:
+      - end: "9999-01-01"
+        organization: RedHat
+        start: "2013-06-03"
+    github_login: objectiser
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Google
+        start: "2013-06-03"
+    email_addresses:
+      - mostrowski@google.com
+    github_login: ostromart
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Google
+        start: "2013-06-03"
+    email_addresses:
+      - ozben@google.com
+    github_login: ozevren
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Google
+        start: "2013-06-03"
+    email_addresses:
+      - philliple@google.com
+    github_login: pitlv2109
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Google
+        start: "2013-06-03"
+    github_login: qiwzhang
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Google
+        start: "2013-06-03"
+    email_addresses:
+      - quanlin@google.com
+    github_login: quanjielin
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Google
+        start: "2013-06-03"
+    email_addresses:
+      - grca@google.com
+    github_login: rcaballeromx
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Google
+        start: "2019-04-08"
+    email_addresses:
+      - iamwen@google.com
+    github_login: richardwxn
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Google
+        start: "2013-06-03"
+    github_login: rkpagadala
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Google
+        start: "2018-10-22"
+    email_addresses:
+      - rlenglet@google.com
+    github_login: rlenglet
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Ant
+        start: "2013-06-03"
+    email_addresses:
+      - jimmysong@jimmysong.io
+    github_login: rootsongjc
+  - affiliations:
+      - end: "2018-02-15"
+        organization: IBM
+        start: "2013-06-03"
+      - end: "2019-03-15"
+        organization: VMWare
+        start: "2018-02-15"
+      - end: "9999-01-01"
+        organization: Tetrate
+        start: "2019-03-15"
+    email_addresses:
+      - rshriram@gmail.com
+    github_login: rshriram
+  - affiliations:
+      - end: "9999-01-01"
+        organization: IBM
+        start: "2018-06-01"
+    github_login: rvennam
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Cisco
+        start: "2005-11-25"
+    email_addresses:
+      - sbezverk@cisco.com
+    github_login: sbezverk
+  - affiliations:
+      - end: "2018-11-25"
+        organization: Cisco
+        start: "2015-02-07"
+      - end: "2019-05-15"
+        organization: NetApp
+        start: "2019-01-03"
+      - end: "9999-01-01"
+        organization: IBM
+        start: "2019-07-02"
+    email_addresses:
+      - steven.dake@gmail.com
+    github_login: sdake
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Google
+        start: "2013-06-03"
+    email_addresses:
+      - sebvas@google.com
+    github_login: sebastienvas
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Google
+        start: "2015-11-16"
+    github_login: selmanj
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Google
+        start: "2006-05-12"
+    email_addresses:
+      - sven@google.com
+    github_login: smawson
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Google
+        start: "2019-05-28"
+    email_addresses:
+      - crwilson@google.com
+    github_login: sushicw
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Google
+        start: "2011-08-01"
+    github_login: tangiel
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Google
+        start: "2016-11-16"
+    github_login: theganyo
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Google
+        start: "2013-06-03"
+    email_addresses:
+      - mitchconnors@google.com
+    github_login: therealmitchconnors
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Cisco
+        start: "2000-12-18"
+    email_addresses:
+      - tiswanso@cisco.com
+    github_login: tiswanso
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Google
+        start: "2013-06-03"
+    email_addresses:
+      - skidam@google.com
+    github_login: utka
+  - affiliations:
+      - end: "9999-01-01"
+        organization: IBM
+        start: "2013-06-03"
+    email_addresses:
+      - vadime@il.ibm.com
+    github_login: vadimeisenbergibm
+  - affiliations:
+      - end: "9999-01-01"
+        organization: VMWare
+        start: "2013-06-03"
+    email_addresses:
+      - veniln@vmware.com
+    github_login: venilnoronha
+  - affiliations:
+      - end: "9999-01-01"
+        organization: IBM
+        start: "2004-05-26"
+    github_login: vikramkhatri
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Google
+        start: "2013-06-03"
+    email_addresses:
+      - lita@google.com
+    github_login: wattli
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Google
+        start: "2013-06-03"
+    github_login: xiaolanz
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Google
+        start: "2016-01-05"
+    email_addresses:
+      - ymzhu@google.com
+    github_login: yangminzhu
+  - affiliations:
+      - end: "2019-03-15"
+        organization: IBM
+        start: "2013-06-03"
+      - end: "9999-01-01"
+        organization: DellEMC
+        start: "2019-03-15"
+    github_login: ymesika
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Google
+        start: "2013-06-03"
+    github_login: yutongz
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Google
+        start: "2019-04-15"
+    email_addresses:
+      - yxyan@google.com
+    github_login: yxue
+  - affiliations:
+      - end: "0001-01-01"
+        organization: Pivotal
+        start: "2019-10-15"
+    github_login: xanderstrike
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Google
+        start: "0001-01-01"
+    github_login: adammil2000
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Cisco
+        start: "0001-01-01"
+    github_login: baodongli
+  - affiliations:
+      - end: "9999-01-01"
+        organization: RedHat
+        start: "0001-01-01"
+    github_login: brian-avery
+  - affiliations:
+      - end: "9999-01-01"
+        organization: IBM
+        start: "0001-01-01"
+    github_login: cmluciano
+  - affiliations:
+      - end: "9999-01-01"
+        organization: RedHat
+        start: "0001-01-01"
+    github_login: dmitri-d
+  - affiliations:
+      - end: "9999-01-01"
+        organization: IBM
+        start: "0001-01-01"
+    github_login: elevran
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Banzai Cloud
+        start: "0001-01-01"
+    github_login: matyix
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Google
+        start: "0001-01-01"
+    github_login: jasminejaksic
+  - affiliations:
+      - end: "9999-01-01"
+        organization: RedHat
+        start: "0001-01-01"
+    github_login: knrc
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Mercari
+        start: "0001-01-01"
+    github_login: zchee
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Banzai Cloud
+        start: "0001-01-01"
+    github_login: Laci21
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Banzai Cloud
+        start: "0001-01-01"
+    github_login: martonsereg
+  - affiliations:
+      - end: "9999-01-01"
+        organization: SUSE
+        start: "0001-01-01"
+    github_login: Nino-K
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Red Hat
+        start: "0001-01-01"
+    github_login: rcernich
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Tigera
+        start: "0001-01-01"
+    github_login: spikecurtis
+  - affiliations:
+      - end: "9999-01-01"
+        organization: IBM
+        start: "0001-01-01"
+    github_login: suryadu
+  - affiliations:
+      - end: "9999-01-01"
+        organization: RedHat
+        start: "0001-01-01"
+    github_login: tvieira
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Banzai Cloud
+        start: "0001-01-01"
+    github_login: waynz0r
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Google
+        start: "0001-01-01"
+    github_login: lambdai
+  - affiliations:
+      - end: "9999-01-01"
+        organization: Red Hat
+        start: "0001-01-01"
+    github_login: mwringe


### PR DESCRIPTION
- Added the boilerplate cleanup filter.
This bot lets you match PR and issue bodies against a regex to perform some replacements
We use this to remove out boilerplate text from PRs and issues.

- Implement support to expand team names in CODEOWNERS files.

- Add support for the new Merged column in the PullRequestEvents and PullRequests tables.

- Fix synchronous creation of events to use the event's time instead of the current wall-clock
time. This address bug where reconciliation with GitHub was always complaining about mismatches
in time and creating duplicate entries in the table.

- Update the base date we probe the GitHub archive with to avoid the limit of not being
to query more than 1000 days at a time from BigQuery. Left some TODOs in the code
to fix this in a more robust way at some point.

- Record the complete known list of user affiliation in userdata.yaml
