### PR TITLE
Add a CRD update nagger

### DIFF
--- a/policybot/policybot.yaml
+++ b/policybot/policybot.yaml
@@ -17,6 +17,12 @@ nags:
     absentfiles:
       - ".*_test.go$"
     message: "🤔 🐛 You appear to be fixing a bug in Go code, yet your PR doesn't include updates to any test files. Did you forget to add a test?"
+  - name: CRD Update
+    matchfiles:
+      - ".*kubernetes/customresourcedefinitions.gen.yaml$"
+    message: |
+      🤔 The generated Custom Resource Definitions file seems to be updated. 
+      Please remember to update the CRD files in [istio/istio](https://www.github.com/istio/istio) repo with `make update-crds` and submit a PR there."
 
 flakechaser:
   name: flakey-test

--- a/policybot/policybot.yaml
+++ b/policybot/policybot.yaml
@@ -18,6 +18,8 @@ nags:
       - ".*_test.go$"
     message: "🤔 🐛 You appear to be fixing a bug in Go code, yet your PR doesn't include updates to any test files. Did you forget to add a test?"
   - name: CRD Update
+    matchtitle:
+      - ".*"
     matchfiles:
       - ".*kubernetes/customresourcedefinitions.gen.yaml$"
     message: |


### PR DESCRIPTION
To remind folks about CRD update in istio/istio repo.

Ideally, nags can be configured per repo, but this rule is restrictive enough now that only api repo has the file.