### PR TITLE
PolicyBot improvements

### DIFF
--- a/policybot/cmd/lifecyclemgr.go
+++ b/policybot/cmd/lifecyclemgr.go
@@ -18,12 +18,14 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"time"
 
 	"github.com/spf13/cobra"
 
 	"istio.io/bots/policybot/mgrs/lifecyclemgr"
 	"istio.io/bots/policybot/pkg/config"
 	"istio.io/bots/policybot/pkg/gh"
+	"istio.io/bots/policybot/pkg/storage/cache"
 	"istio.io/bots/policybot/pkg/storage/spanner"
 )
 
@@ -48,6 +50,8 @@ func runLifecycleMgr(a *config.Args, _ []string) error {
 	}
 	defer store.Close()
 
-	mgr := lifecyclemgr.New(gc, store, a)
+	cache := cache.New(store, time.Duration(a.CacheTTL))
+
+	mgr := lifecyclemgr.New(gc, store, cache, a)
 	return mgr.ManageAll(context.Background())
 }

--- a/policybot/cmd/server.go
+++ b/policybot/cmd/server.go
@@ -182,7 +182,7 @@ func runWithConfig(a *config.Args) error {
 		return fmt.Errorf("unable to create config monitor: %v", err)
 	}
 
-	lf := lifecyclemgr.New(gc, store, a)
+	lf := lifecyclemgr.New(gc, store, cache, a)
 
 	// github webhook filters (keep refresher first in the list such that other filter see an up-to-date view in storage)
 	filters := []githubwebhook.Filter{

--- a/policybot/policybot.yaml
+++ b/policybot/policybot.yaml
@@ -35,13 +35,13 @@ lifecycle:
 
   stale_comment: >
     🧭 This issue or pull request has been automatically marked as stale because it has not had activity
-    from an Istio team member in the last %d days. It will be closed on %s unless an Istio team member takes
+    from an Istio team member since %v. It will be closed on %s unless an Istio team member takes
     action. Please see [this wiki page](https://github.com/istio/istio/wiki/Issue-and-Pull-Request-Lifecycle-Manager) for more information.
     Thank you for your contributions.
 
   close_comment: >
     🚧 This issue or pull request has been closed due to not having had activity from an Istio team member
-    in the last %d days. If you feel this issue or pull request deserves attention, please reopen
+    since %v. If you feel this issue or pull request deserves attention, please reopen
     the issue. Please see [this wiki page](https://github.com/istio/istio/wiki/Issue-and-Pull-Request-Lifecycle-Manager) for more information.
     Thank you for your contributions.
 


### PR DESCRIPTION
- Correctly include PR review comments as a form of member activity. This removes
staleness from items.

- Realtime lifecycle management now works for PRs in addition to issues. PRs used
to be tackled only once a day during reconciliation.

- Fix dynamic reloading of updated config state.

- Go through the cache for a few reads to improve perf a tad.