### PR TITLE
Fix bug causing the bot to update comments when it shouldn't.

### DIFF
--- a/policybot/mgrs/lifecyclemgr/mgr.go
+++ b/policybot/mgrs/lifecyclemgr/mgr.go
@@ -248,7 +248,8 @@ func (lm *LifecycleMgr) manageIssue(context context.Context, issue *storage.Issu
 		}
 
 		// add closing comment
-		if err := lm.addComment(context, issue, fmt.Sprintf(lm.config.CloseComment, latestMemberComment), "closing"); err != nil {
+		commentDate := latestMemberComment.Format("2006-01-02")
+		if err := lm.addComment(context, issue, fmt.Sprintf(lm.config.CloseComment, commentDate), "closing"); err != nil {
 			return err
 		}
 
@@ -261,11 +262,12 @@ func (lm *LifecycleMgr) manageIssue(context context.Context, issue *storage.Issu
 	} else if latestMemberCommentDelta > staleDelay {
 		when := now.Add(closeDelay - staleDelay)
 		closeDate := when.Format("2006-01-02")
+		commentDate := latestMemberComment.Format("2006-01-02")
 
 		st.markedStale++
 
 		// add staleness comment
-		if err := lm.addComment(context, issue, fmt.Sprintf(lm.config.StaleComment, latestMemberComment, closeDate), "staleness"); err != nil {
+		if err := lm.addComment(context, issue, fmt.Sprintf(lm.config.StaleComment, commentDate, closeDate), "staleness"); err != nil {
 			return err
 		}
 

--- a/policybot/pkg/gh/comments.go
+++ b/policybot/pkg/gh/comments.go
@@ -97,7 +97,7 @@ func FindBotComment(context context.Context, gc *ThrottledClient, orgLogin strin
 		for _, comment := range comments.([]*github.IssueComment) {
 			body := comment.GetBody()
 			if strings.Contains(body, signature) {
-				return body, comment.GetID(), nil
+				return strings.ReplaceAll(body, "\r\n", "\n"), comment.GetID(), nil
 			}
 		}
 


### PR DESCRIPTION
- GitHub normalizes \n to \r\n which was causing my comparison logic to fail.
Now, the bot recognizes that a given comment has already been applied and won't
apply it again.

- In the staleness and close comments, use the right format for output the date a
PR/issue was last manipulated by a member. It was including time & timezone,
now it's just the date proper.