### PR TITLE
Synchronously query ZenHub for priority info as part of lifecycle management

### DIFF
--- a/policybot/cmd/server.go
+++ b/policybot/cmd/server.go
@@ -22,6 +22,8 @@ import (
 	"net/http"
 	"time"
 
+	"istio.io/bots/policybot/pkg/zh"
+
 	"github.com/gorilla/mux"
 	"github.com/spf13/cobra"
 
@@ -127,6 +129,7 @@ func runWithConfig(a *config.Args) error {
 	}
 
 	gc := gh.NewThrottledClient(context.Background(), a.Secrets.GitHubToken)
+	zc := zh.NewThrottledClient(a.Secrets.ZenHubToken)
 	_ = util.NewMailer(a.Secrets.SendGridAPIKey, a.EmailFrom, a.EmailOriginAddress)
 
 	store, err := spanner.NewStore(context.Background(), a.SpannerDatabase, creds)
@@ -188,7 +191,7 @@ func runWithConfig(a *config.Args) error {
 	filters := []githubwebhook.Filter{
 		refresher.NewRefresher(cache, store, gc, a.Orgs),
 		nag,
-		lifecycler.New(gc, a.Orgs, lf, cache),
+		lifecycler.New(gc, zc, a.Orgs, lf, cache),
 		labeler,
 		cleaner,
 		monitor,

--- a/policybot/pkg/storage/cache/cache.go
+++ b/policybot/pkg/storage/cache/cache.go
@@ -316,6 +316,20 @@ func (c *Cache) ReadIssuePipeline(context context.Context, orgLogin string, repo
 	return result, err
 }
 
+// Writes to DB and if successful, updates the cache
+func (c *Cache) WriteIssuePipelines(context context.Context, pipelines []*storage.IssuePipeline) error {
+	err := c.store.WriteIssuePipelines(context, pipelines)
+	if err == nil {
+		for _, pipeline := range pipelines {
+			c.pipelineCache.Set(pipeline.OrgLogin+
+				pipeline.RepoName+
+				strconv.Itoa(int(pipeline.IssueNumber)), pipeline)
+		}
+	}
+
+	return err
+}
+
 func (c *Cache) ReadTestResult(context context.Context,
 	orgLogin string, repoName string, testName string, prNum int64, runNumber int64) (*storage.TestResult, error) {
 	key := orgLogin + repoName + testName + strconv.FormatInt(prNum, 10) + strconv.FormatInt(runNumber, 10)


### PR DESCRIPTION
This will hopefully improve behavior around the `needs triage` label