### PR TITLE
fix typescript config

### DIFF
--- a/policybot/tsconfig.json
+++ b/policybot/tsconfig.json
@@ -9,6 +9,7 @@
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,
     "alwaysStrict": true,
+    "strictNullChecks": false,
     "checkJs": false,
     "noFallthroughCasesInSwitch": true,
     "noImplicitAny": true,


### PR DESCRIPTION
Failure on `make gen`.

```console
dashboard/ts/core/sidebar.ts(72,13): error TS2322: Type 'null' is not assignable to type 'string'.
```
ref: https://storage.googleapis.com/istio-prow/logs/deploy-policybot_bots_postsubmit/1/build-log.txt

> The alternative is the fix the type. I am not sure which is preferred.