### PR TITLE
Enable welcomer bot for istio/test-infra

### DIFF
--- a/policybot/config/welcome/test-infra.yaml
+++ b/policybot/config/welcome/test-infra.yaml
@@ -1,0 +1,14 @@
+name: test-infra
+type: welcome
+repos:
+  - "istio/test-infra"
+
+resenddays: 90
+message: |
+  😊 Welcome! This is either your first contribution to the Istio test infrastructure repo, or
+  it's been awhile since you've been here.
+
+  You can learn more about the Istio working groups, code of conduct, and contributing guidelines
+  by referring to [Contributing to Istio](https://github.com/istio/community/blob/master/CONTRIBUTING.md).
+
+  Thanks for contributing!


### PR DESCRIPTION
This is an implementation of the `welcomer` plugin for the policybot. We need to decide what *"content"* the message should contain before rolling this out.

ref: https://github.com/istio/test-infra/issues/2213

cc @istio/wg-test-and-release-maintainers 