### PR TITLE
Update cron-syncmgr-testresults.yaml

### DIFF
--- a/policybot/deploy/policybot/templates/cron-syncmgr-testresults.yaml
+++ b/policybot/deploy/policybot/templates/cron-syncmgr-testresults.yaml
@@ -26,4 +26,4 @@ spec:
               envFrom:
                 - secretRef:
                     name: policybot
-          restartPolicy: OnFailure
+          restartPolicy: Never


### PR DESCRIPTION
restarting failed containers without restarting the pod causes failures to go on indefinitely, preventing future jobs from running.  Causing the pod to fail will allow the job to be marked as failure after a default of 6 times.