### PR TITLE
Update test nag to not fire for updated testdata

### DIFF
--- a/policybot/config/nags/go.yaml
+++ b/policybot/config/nags/go.yaml
@@ -9,4 +9,5 @@ matchfiles:
   - ".*.go$"
 absentfiles:
   - ".*_test.go$"
+  - ".*/testdata/.+"
 message: "🤔 🐛 You appear to be fixing a bug in Go code, yet your PR doesn't include updates to any test files. Did you forget to add a test?"


### PR DESCRIPTION
Makes the test nag bot a tiny bit smarter, so it doesn't fire if testdata is updated. 
Example PR where this happens: https://github.com/istio/istio/pull/19905

