### PR TITLE
Add cache update to test results bot job

### DIFF
--- a/policybot/mgrs/syncmgr/mgr.go
+++ b/policybot/mgrs/syncmgr/mgr.go
@@ -1176,6 +1176,12 @@ func (ss *syncState) handleTestResults() error {
 		if result != nil {
 			return result
 		}
+		// Update cache table to reflect these results.
+		rowCount, err := ss.mgr.store.UpdateFlakeCache(ss.ctx)
+		if err != nil {
+			return err
+		}
+		log.Infof("Updated flake cache with %d additional flakes", rowCount)
 		// TODO: check Post Submit tests as well.
 	}
 

--- a/policybot/pkg/storage/store.go
+++ b/policybot/pkg/storage/store.go
@@ -49,6 +49,7 @@ type Store interface {
 	WriteAllUserAffiliations(context context.Context, affiliation []*UserAffiliation) error
 
 	UpdateBotActivity(context context.Context, orgLogin string, repoName string, cb func(*BotActivity) error) error
+	UpdateFlakeCache(context context.Context) (int, error)
 
 	ReadOrg(context context.Context, orgLogin string) (*Org, error)
 	ReadRepo(context context.Context, orgLogin string, repoName string) (*Repo, error)


### PR DESCRIPTION
This cache allows for rapid querying of flaked tests.