### PR TITLE
Prevent pipelines from passing nil errors on To()

### DIFF
--- a/policybot/pkg/pipeline/pipeline.go
+++ b/policybot/pkg/pipeline/pipeline.go
@@ -257,8 +257,11 @@ func (sp *Impl) To(f func(result interface{}) error) End {
 		input := t.Transform(nx.ctx, in, g)
 		go func() {
 			for i := range input {
-				// this nonsense is necessary because channels don't support inheritance
-				result <- i
+				// For enders, we don't report output unless there has been an error
+				if i.Err() != nil {
+					// this nonsense is necessary because channels don't support inheritance
+					result <- i
+				}
 			}
 			close(result)
 		}()

--- a/policybot/pkg/pipeline/pipeline_test.go
+++ b/policybot/pkg/pipeline/pipeline_test.go
@@ -79,8 +79,6 @@ func TestPipeline(t *testing.T) {
 	assert.Equal(t, rescount, 4)
 }
 
-
-
 func TestNilErrors(t *testing.T) {
 	// This is a sample data source that emits numbers as text
 	// it will skip emitting "two" to demonstrate that feature

--- a/policybot/pkg/pipeline/pipeline_test.go
+++ b/policybot/pkg/pipeline/pipeline_test.go
@@ -78,3 +78,32 @@ func TestPipeline(t *testing.T) {
 	assert.Equal(t, errcount, 1)
 	assert.Equal(t, rescount, 4)
 }
+
+
+
+func TestNilErrors(t *testing.T) {
+	// This is a sample data source that emits numbers as text
+	// it will skip emitting "two" to demonstrate that feature
+	d := testDataSource{
+		source: []interface{}{"zero", "one", "two", "three", "four", "five"},
+		errMap: map[int]error{2: ErrSkip, 5: errors.New("foo")},
+	}
+	// this is an async test, so if it hasn't finished in a minute, exit
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+	var errcount, rescount int
+	// from our datasource, transform the text to describe piggies
+	out := From(d.iterate).WithContext(ctx).WithBuffer(2).
+		To(func(i interface{}) error {
+			rescount++
+			return nil
+		}).Go()
+
+	for result := range out {
+		errcount++
+		fmt.Printf("checking result %v\n", result)
+		assert.NilError(t, result.Err())
+	}
+	assert.Equal(t, errcount, 0)
+	assert.Equal(t, rescount, 4)
+}


### PR DESCRIPTION
This is causing the 0 errors occurred message in the bots.  