### PR TITLE
Welcomer: exclude current PR from resend logic

### DIFF
--- a/policybot/handlers/githubwebhook/welcomer/welcomer.go
+++ b/policybot/handlers/githubwebhook/welcomer/welcomer.go
@@ -89,9 +89,9 @@ func (w *Welcomer) Handle(context context.Context, event interface{}) {
 func (w *Welcomer) processPR(context context.Context, pr *storage.PullRequest, welcome *welcomeRecord) {
 	latest := time.Time{}
 
-	if err := w.store.QueryPullRequestsByUser(context, pr.OrgLogin, pr.RepoName, pr.Author, func(pr *storage.PullRequest) error {
-		if pr.CreatedAt.After(latest) {
-			latest = pr.CreatedAt
+	if err := w.store.QueryPullRequestsByUser(context, pr.OrgLogin, pr.RepoName, pr.Author, func(prResult *storage.PullRequest) error {
+		if pr.PullRequestNumber != prResult.PullRequestNumber && prResult.CreatedAt.After(latest) {
+			latest = prResult.CreatedAt
 		}
 
 		return nil


### PR DESCRIPTION
The `welcomer` was **not** running because it was including the *current* PR (i.e. the one from the triggered *opened* event) when checking the time against `ResendDays`. This change *excludes* that PR.

fix https://github.com/istio/test-infra/issues/2213