### PR TITLE
Nagger should rescan PR on updates

### DIFF
--- a/policybot/handlers/githubwebhook/nagger/nagger.go
+++ b/policybot/handlers/githubwebhook/nagger/nagger.go
@@ -110,7 +110,7 @@ func (n *Nagger) Handle(context context.Context, event interface{}) {
 	scope.Infof("Received PullRequestEvent: %s, %d, %s", prp.GetRepo().GetFullName(), prp.GetPullRequest().GetNumber(), prp.GetAction())
 
 	action := prp.GetAction()
-	if action != "opened" && action != "edited" {
+	if action != "opened" && action != "edited" && action != "synchronize" {
 		scope.Infof("Ignoring event for PR %d from repo %s since it doesn't have a supported action: %s", prp.GetNumber(), prp.GetRepo().GetFullName(), action)
 		return
 	}


### PR DESCRIPTION
The `nagger` should reprocess PRs when they are updated (i.e. on [`synchronize`](https://github.blog/2011-10-19-all-of-the-hooks/) event).

**e.g.**
 
This PR (https://github.com/istio/test-infra/pull/2446) was created without `go` tests but was subsequently updated to include them, yet the `nagger` [comment](https://github.com/istio/test-infra/pull/2446#issuecomment-592752972) was not removed.

https://github.com/istio/test-infra/pull/2446