### PR TITLE
Nagger should refresh data on updates

### DIFF
--- a/policybot/handlers/githubwebhook/refresher/refresher.go
+++ b/policybot/handlers/githubwebhook/refresher/refresher.go
@@ -153,7 +153,7 @@ func (r *Refresher) Handle(context context.Context, event interface{}) {
 			}
 		}
 
-		if action == "opened" || action == "edited" {
+		if action == "opened" || action == "edited" || action == "synchronize" {
 			opt := &github.ListOptions{
 				PerPage: 100,
 			}


### PR DESCRIPTION
The action processing for **nagger** was fixed here: https://github.com/istio/bots/pull/141. This ensures the  persistent data is refreshed as well on `synchronize` event, otherwise the processing will occur on stale data.