### PR TITLE
This renames `type` to `feature` and adds boilerplate cleanup for feature

### DIFF
--- a/policybot/config/autolabels/multi-cluster.yaml
+++ b/policybot/config/autolabels/multi-cluster.yaml
@@ -3,6 +3,6 @@ type: autolabel
 matchbody:
   - "\\[ ?x ?\\] ?Multi Cluster"
 absentlabels:
-  - "type/.?"
+  - "feature/.?"
 labelstoapply:
-  - type/multi-cluster
+  - feature/multi-cluster

--- a/policybot/config/autolabels/multi-control-plane.yaml
+++ b/policybot/config/autolabels/multi-control-plane.yaml
@@ -3,6 +3,6 @@ type: autolabel
 matchbody:
   - "\\[ ?x ?\\] ?Multi Control Plane"
 absentlabels:
-  - "type/.?"
+  - "feature/.?"
 labelstoapply:
-  - type/multi-control-plane
+  - feature/multi-control-plane

--- a/policybot/config/autolabels/virtual-machine.yaml
+++ b/policybot/config/autolabels/virtual-machine.yaml
@@ -3,6 +3,6 @@ type: autolabel
 matchbody:
   - "\\[ ?x ?\\] ?Virtual Machine"
 absentlabels:
-  - "type/.?"
+  - "feature/.?"
 labelstoapply:
-  - type/virtual-machine
+  - feature/virtual-machine

--- a/policybot/config/boilerplates/feature-selection-banner.yaml
+++ b/policybot/config/boilerplates/feature-selection-banner.yaml
@@ -1,0 +1,4 @@
+name: Feature selection banner
+type: boilerplate
+regex: |
+  \*\*Affected features \(please put an X in all that apply\)\*\*

--- a/policybot/config/boilerplates/feature-selection.yaml
+++ b/policybot/config/boilerplates/feature-selection.yaml
@@ -1,0 +1,7 @@
+name: Feature selection
+type: boilerplate
+regex: |
+  ^\[[ \w]\] +Multi Cluster
+  \[[ \w]\] +Virtual Machine
+  \[[ \w]\] +Multi Control Plane
+


### PR DESCRIPTION
After discussing, we decided that calling functionality feature/* instead of type/* was more self explanatory, so this PR corrects that. This PR also adds cleanup for boilerplate for features.