### PR TITLE
Fixed regex to match autolabels

### DIFF
--- a/policybot/config/boilerplates/area-selection.yaml
+++ b/policybot/config/boilerplates/area-selection.yaml
@@ -1,13 +1,13 @@
 name: Area selection
 type: boilerplate
 regex: |
-  ^\\[ ?x ?\\] ?Configuration Infrastructure
-  \\[ ?x ?\\] ?Docs
-  \\[ ?x ?\\] ?Installation
-  \\[ ?x ?\\] ?Networking
-  \\[ ?x ?\\] ?Performance and Scalability
-  \\[ ?x ?\\] ?Policies and Telemetry
-  \\[ ?x ?\\] ?Security
-  \\[ ?x ?\\] ?Test and Release
-  \\[ ?x ?\\] ?User Experience
-  \\[ ?x ?\\] ?Developer Infrastructure
+  ^\[ ?[ \w] ?\] +Configuration Infrastructure
+  \[ ?[ \w] ?\] +Docs
+  \[ ?[ \w] ?\] +Installation
+  \[ ?[ \w] ?\] +Networking
+  \[ ?[ \w] ?\] +Performance and Scalability
+  \[ ?[ \w] ?\] +Policies and Telemetry
+  \[ ?[ \w] ?\] +Security
+  \[ ?[ \w] ?\] +Test and Release
+  \[ ?[ \w] ?\] +User Experience
+  \[ ?[ \w] ?\] +Developer Infrastructure

--- a/policybot/config/boilerplates/area-selection.yaml
+++ b/policybot/config/boilerplates/area-selection.yaml
@@ -1,13 +1,13 @@
 name: Area selection
 type: boilerplate
 regex: |
-  ^\[[ \w]\] +Configuration Infrastructure
-  \[[ \w]\] +Docs
-  \[[ \w]\] +Installation
-  \[[ \w]\] +Networking
-  \[[ \w]\] +Performance and Scalability
-  \[[ \w]\] +Policies and Telemetry
-  \[[ \w]\] +Security
-  \[[ \w]\] +Test and Release
-  \[[ \w]\] +User Experience
-  \[[ \w]\] +Developer Infrastructure
+  ^\\[ ?x ?\\] ?Configuration Infrastructure
+  \\[ ?x ?\\] ?Docs
+  \\[ ?x ?\\] ?Installation
+  \\[ ?x ?\\] ?Networking
+  \\[ ?x ?\\] ?Performance and Scalability
+  \\[ ?x ?\\] ?Policies and Telemetry
+  \\[ ?x ?\\] ?Security
+  \\[ ?x ?\\] ?Test and Release
+  \\[ ?x ?\\] ?User Experience
+  \\[ ?x ?\\] ?Developer Infrastructure

--- a/policybot/config/boilerplates/feature-selection.yaml
+++ b/policybot/config/boilerplates/feature-selection.yaml
@@ -1,7 +1,7 @@
 name: Feature selection
 type: boilerplate
 regex: |
-  ^\[[ \w]\] +Multi Cluster
-  \[[ \w]\] +Virtual Machine
-  \[[ \w]\] +Multi Control Plane
+  ^\\[ ?x ?\\] ?Multi Cluster
+  \\[ ?x ?\\] ?Virtual Machine
+  \\[ ?x ?\\] ?Multi Control Plane
 

--- a/policybot/config/boilerplates/feature-selection.yaml
+++ b/policybot/config/boilerplates/feature-selection.yaml
@@ -1,7 +1,7 @@
 name: Feature selection
 type: boilerplate
 regex: |
-  ^\\[ ?x ?\\] ?Multi Cluster
-  \\[ ?x ?\\] ?Virtual Machine
-  \\[ ?x ?\\] ?Multi Control Plane
+  ^\[ ?[ \w] ?\] +Multi Cluster
+  \[ ?[ \w] ?\] +Virtual Machine
+  \[ ?[ \w] ?\] +Multi Control Plane
 


### PR DESCRIPTION
Currently, issues like: https://github.com/istio/istio/issues/22508 leave extra text when the cleaner runs:
Describe the feature request

In the move to istiod, the code paths for the functionality formerly provided by istio-galley and istio-citadel do not export the metrics that were previously used for monitoring. While we don't need 100% duplication, we should have proper monitoring of those code paths and exposed functionality.

Describe alternatives you've considered

[ X ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ X ] Networking
[ ] Performance and Scalability
[ X ] Policies and Telemetry
[ X ] Security
[ ] Test and Release
[ X ] User Experience
[ ] Developer Infrastructure

Additional context

This PR copies the regex from autolabel in order to make them behave the same.