### PR TITLE
push bots image to ubuntu:19.10 since 19.04 is no longer supported

### DIFF
--- a/policybot/Dockerfile
+++ b/policybot/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:disco
+FROM ubuntu:eoan
 
 ENV CA_CERTIFICATES_VERSION=20190110
 


### PR DESCRIPTION
deploy jobs are failing like 
https://prow.istio.io/view/gs/istio-prow/logs/deploy-policybot_bots_postsubmit/33