### PR TITLE
ignore '429 too many requests' responses during link checking.

### DIFF
--- a/common/Makefile.common.mk
+++ b/common/Makefile.common.mk
@@ -49,7 +49,7 @@ lint-markdown:
 	@${FINDFILES} -name '*.md' -print0 | ${XARGS} mdl --ignore-front-matter --style common/config/mdl.rb
 
 lint-links:
-	@${FINDFILES} -name '*.md' -print0 | ${XARGS} awesome_bot --skip-save-results --allow_ssl --allow-timeout --allow-dupe --allow-redirect --white-list ${MARKDOWN_LINT_WHITELIST}
+	@${FINDFILES} -name '*.md' -print0 | ${XARGS} awesome_bot --skip-save-results --allow 429 --allow_ssl --allow-timeout --allow-dupe --allow-redirect --white-list ${MARKDOWN_LINT_WHITELIST}
 
 lint-sass:
 	@${FINDFILES} -name '*.scss' -print0 | ${XARGS} sass-lint -c common/config/sass-lint.yml --verbose


### PR DESCRIPTION
Sometimes our linter issues so many requests we get rate limited.

I saw this happen in the istio/community linter.   Adding it here to since it may be more generally useful.