### PR TITLE
Release-notes-none autolable

### DIFF
--- a/policybot/config/autolabels/release-notes.yaml
+++ b/policybot/config/autolabels/release-notes.yaml
@@ -1,0 +1,6 @@
+name: Virtual Machine
+type: autolabel
+matchbody:
+  - "\\[ ?x ?\\] ?Does not have any changes that may affect Istio users."
+labelstoapply:
+  - release-notes-none

--- a/policybot/config/autolabels/release-notes.yaml
+++ b/policybot/config/autolabels/release-notes.yaml
@@ -1,4 +1,4 @@
-name: Virtual Machine
+name: Release-notes-none
 type: autolabel
 matchbody:
   - "\\[ ?x ?\\] ?Does not have any changes that may affect Istio users."


### PR DESCRIPTION
This adds support for auto-labeling `release-notes-none`. With this, any committer that checks the box won't be asked to add a release note to their pull request. 


This will look like: 


Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.