### PR TITLE
Temporarily disable flake detection

### DIFF
--- a/policybot/mgrs/syncmgr/mgr.go
+++ b/policybot/mgrs/syncmgr/mgr.go
@@ -1179,7 +1179,6 @@ func (ss *syncState) handleTestResults() error {
 		if result != nil {
 			return result
 		}
-		log.Infof("Updated flake cache with %d additional flakes", rowCount)
 		// TODO: check Post Submit tests as well.
 	}
 

--- a/policybot/mgrs/syncmgr/mgr.go
+++ b/policybot/mgrs/syncmgr/mgr.go
@@ -1179,11 +1179,6 @@ func (ss *syncState) handleTestResults() error {
 		if result != nil {
 			return result
 		}
-		// Update cache table to reflect these results.
-		rowCount, err := ss.mgr.store.UpdateFlakeCache(ss.ctx)
-		if err != nil {
-			return err
-		}
 		log.Infof("Updated flake cache with %d additional flakes", rowCount)
 		// TODO: check Post Submit tests as well.
 	}


### PR DESCRIPTION
This query is killing the database, which hosts many other functions.  We need to re-evaluate how we do this...