### PR TITLE
disable all activity on TestResults table to mitigate outage

### DIFF
--- a/policybot/dashboard/topics/postsubmit/topic.go
+++ b/policybot/dashboard/topics/postsubmit/topic.go
@@ -23,13 +23,13 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/gorilla/mux"
+	"github.com/robfig/cron/v3"
+
 	"istio.io/bots/policybot/dashboard/types"
 	"istio.io/bots/policybot/pkg/storage"
 	"istio.io/bots/policybot/pkg/storage/cache"
 	"istio.io/pkg/log"
-
-	"github.com/gorilla/mux"
-	"github.com/robfig/cron/v3"
 )
 
 // PostSubmit lets users visualize critical information about which features have been covered and which not after Github PR merged.
@@ -106,7 +106,7 @@ func New(store storage.Store, cache *cache.Cache, router *mux.Router) *PostSubmi
 	if err != nil {
 		log.Errorf("add caching latest 100 BaseSha cron job: %s", err)
 	}
-	cron.Start()
+	//cron.Start()
 	return ps
 }
 

--- a/policybot/handlers/githubwebhook/refresher/refresher.go
+++ b/policybot/handlers/githubwebhook/refresher/refresher.go
@@ -132,27 +132,27 @@ func (r *Refresher) Handle(context context.Context, event interface{}) {
 
 		action := p.GetAction()
 
-		rec, ok := r.reg.SingleRecord(RecordType, p.GetRepo().GetFullName())
-		if ok {
-			ref := rec.(*TestOutputRecord)
-			orgLogin := p.GetRepo().GetOwner().GetLogin()
-			repoName := p.GetRepo().GetName()
-			prNum := p.GetNumber()
+		//rec, ok := r.reg.SingleRecord(RecordType, p.GetRepo().GetFullName())
+		//if ok {
+		//ref := rec.(*TestOutputRecord)
+		//orgLogin := p.GetRepo().GetOwner().GetLogin()
+		//repoName := p.GetRepo().GetName()
+		//prNum := p.GetNumber()
+		//
+		//tg := gatherer.TestResultGatherer{
+		//	Client:           r.bs,
+		//	BucketName:       ref.BucketName,
+		//	PreSubmitPrefix:  ref.PreSubmitTestPath,
+		//	PostSubmitPrefix: ref.PostSubmitTestPath,
+		//}
 
-			tg := gatherer.TestResultGatherer{
-				Client:           r.bs,
-				BucketName:       ref.BucketName,
-				PreSubmitPrefix:  ref.PreSubmitTestPath,
-				PostSubmitPrefix: ref.PostSubmitTestPath,
-			}
-
-			testResults, err := tg.CheckTestResultsForPr(context, orgLogin, repoName, strconv.Itoa(prNum))
-			if err != nil {
-				scope.Errorf("Unable to get test result for PR %d in repo %s: %v", prNum, p.GetRepo().GetFullName(), err)
-			} else if err = r.cache.WriteTestResults(context, testResults); err != nil {
-				scope.Errorf("Unable to write test results: %v", err)
-			}
-		}
+		//testResults, err := tg.CheckTestResultsForPr(context, orgLogin, repoName, strconv.Itoa(prNum))
+		//if err != nil {
+		//	scope.Errorf("Unable to get test result for PR %d in repo %s: %v", prNum, p.GetRepo().GetFullName(), err)
+		//} else if err = r.cache.WriteTestResults(context, testResults); err != nil {
+		//	scope.Errorf("Unable to write test results: %v", err)
+		//}
+		//}
 
 		if action == "opened" || action == "edited" || action == "synchronize" {
 			opt := &github.ListOptions{


### PR DESCRIPTION
This PR should be reverted once the database has stabilized and the bashsha query is analyzed for performance implications.