### PR TITLE
Set SHELL to bash

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+SHELL := /bin/bash -o pipefail
+
 build:
 	@go generate ./...
 	@go build ./...


### PR DESCRIPTION
To avoid this error on `lint-yaml` target:
```
/bin/sh: 1: set: Illegal option -o pipefail
```