### PR TITLE
update release qual test page

### DIFF
--- a/policybot/dashboard/topics/releasequalification/assets.gen.go
+++ b/policybot/dashboard/topics/releasequalification/assets.gen.go
@@ -56,27 +56,50 @@ var _pageHtml = []byte(`<aside class="callout warning">
     </div>
 </aside>
 
-<p>
+<h2>
     This dashboard shows results of release qualification pipeline
-</p>
+</h2>
 
 <p>
     To view the monitor/alert definition, checkout <a href="https://github.com/istio/tools/blob/master/perf/stability/alertmanager/prometheusrule.yaml">PrometheusRule list</a>
 </p>
 
-{{ range $branch, $aggregatedStatus := .StatusByBranch }}
+{{ range $testID, $aggregatedStatus := .StatusByTestID }}
+<div>
+    <h2>Test result for {{ $testID }}</h2>
 <table>
-    <caption>Monitor Status for {{ $branch }}</caption>
+    <caption>Test Info</caption>
+    <thead>
+    <tr>
+        <th>ProjectID</th>
+        <th>ClusterName</th>
+        <th>Branch/SHA/Tag</th>
+        <th>PrometheusLink</th>
+        <th>GrafanaLink</th>
+    </tr>
+    </thead>
+    <tbody>
+        <tr>
+            {{ with (index $.MetadataByTestID $testID) }}
+            <td>{{ .ProjectID }}</td>
+            <td>{{ .ClusterName }}</td>
+            <td>{{ .Branch }}</td>
+            <td>{{ .PrometheusLink }}</td>
+            <td>{{ .GrafanaLink }}</td>
+            {{ end }}
+        </tr>
+    </tbody>
+</table>
+    <p></p>
+<table>
+    <caption>Monitor Status</caption>
     <thead>
     <tr>
         <th>Monitor</th>
         <th>Status</th>
-        <th>ProjectID</th>
-        <th>ClusterName</th>
         <th>UpdatedTime</th>
-        <th>TestID</th>
-        <th>Branch/SHA/Tag</th>
         <th>FiredTimes</th>
+        <th>LastFiredTime</th>
         <th>Description</th>
     </tr>
     </thead>
@@ -89,21 +112,19 @@ var _pageHtml = []byte(`<aside class="callout warning">
             {{ else }}
               <td style="color: red">{{ $singleStatus.Status }}</td>
             {{ end }}
-            <td>{{ $singleStatus.ProjectID }}</td>
-            <td>{{ $singleStatus.ClusterName }}</td>
             <td>{{ $singleStatus.UpdatedTime }}</td>
-            <td>{{ $singleStatus.TestID }}</td>
-            <td>{{ $singleStatus.Branch }}</td>
             {{ if eq $singleStatus.FiredTimes 0 }}
                 <td style="color: green">{{ $singleStatus.FiredTimes }}</td>
             {{ else }}
                 <td style="color: red">{{ $singleStatus.FiredTimes }}</td>
             {{ end }}
+            <td>{{ $singleStatus.LastFiredTime }}</td>
             <td>{{ $singleStatus.Description }}</td>
         </tr>
         {{ end}}
     </tbody>
 </table>
+</div>
 {{ end}}`)
 
 func pageHtmlBytes() ([]byte, error) {

--- a/policybot/dashboard/topics/releasequalification/assets.gen.go
+++ b/policybot/dashboard/topics/releasequalification/assets.gen.go
@@ -56,6 +56,14 @@ var _pageHtml = []byte(`<aside class="callout warning">
     </div>
 </aside>
 
+<p>
+    This dashboard shows results of release qualification pipeline
+</p>
+
+<p>
+    To view the monitor/alert definition, checkout <a href="https://github.com/istio/tools/blob/master/perf/stability/alertmanager/prometheusrule.yaml">PrometheusRule list</a>
+</p>
+
 {{ range $branch, $aggregatedStatus := .StatusByBranch }}
 <table>
     <caption>Monitor Status for {{ $branch }}</caption>
@@ -67,7 +75,9 @@ var _pageHtml = []byte(`<aside class="callout warning">
         <th>ClusterName</th>
         <th>UpdatedTime</th>
         <th>TestID</th>
+        <th>Branch/SHA/Tag</th>
         <th>FiredTimes</th>
+        <th>Description</th>
     </tr>
     </thead>
     <tbody>
@@ -83,11 +93,13 @@ var _pageHtml = []byte(`<aside class="callout warning">
             <td>{{ $singleStatus.ClusterName }}</td>
             <td>{{ $singleStatus.UpdatedTime }}</td>
             <td>{{ $singleStatus.TestID }}</td>
+            <td>{{ $singleStatus.Branch }}</td>
             {{ if eq $singleStatus.FiredTimes 0 }}
                 <td style="color: green">{{ $singleStatus.FiredTimes }}</td>
             {{ else }}
                 <td style="color: red">{{ $singleStatus.FiredTimes }}</td>
             {{ end }}
+            <td>{{ $singleStatus.Description }}</td>
         </tr>
         {{ end}}
     </tbody>

--- a/policybot/dashboard/topics/releasequalification/page.html
+++ b/policybot/dashboard/topics/releasequalification/page.html
@@ -10,27 +10,50 @@
     </div>
 </aside>
 
-<p>
+<h2>
     This dashboard shows results of release qualification pipeline
-</p>
+</h2>
 
 <p>
     To view the monitor/alert definition, checkout <a href="https://github.com/istio/tools/blob/master/perf/stability/alertmanager/prometheusrule.yaml">PrometheusRule list</a>
 </p>
 
-{{ range $branch, $aggregatedStatus := .StatusByBranch }}
+{{ range $testID, $aggregatedStatus := .StatusByTestID }}
+<div>
+    <h2>Test result for {{ $testID }}</h2>
 <table>
-    <caption>Monitor Status for {{ $branch }}</caption>
+    <caption>Test Info</caption>
+    <thead>
+    <tr>
+        <th>ProjectID</th>
+        <th>ClusterName</th>
+        <th>Branch/SHA/Tag</th>
+        <th>PrometheusLink</th>
+        <th>GrafanaLink</th>
+    </tr>
+    </thead>
+    <tbody>
+        <tr>
+            {{ with (index $.MetadataByTestID $testID) }}
+            <td>{{ .ProjectID }}</td>
+            <td>{{ .ClusterName }}</td>
+            <td>{{ .Branch }}</td>
+            <td>{{ .PrometheusLink }}</td>
+            <td>{{ .GrafanaLink }}</td>
+            {{ end }}
+        </tr>
+    </tbody>
+</table>
+    <p></p>
+<table>
+    <caption>Monitor Status</caption>
     <thead>
     <tr>
         <th>Monitor</th>
         <th>Status</th>
-        <th>ProjectID</th>
-        <th>ClusterName</th>
         <th>UpdatedTime</th>
-        <th>TestID</th>
-        <th>Branch/SHA/Tag</th>
         <th>FiredTimes</th>
+        <th>LastFiredTime</th>
         <th>Description</th>
     </tr>
     </thead>
@@ -43,19 +66,17 @@
             {{ else }}
               <td style="color: red">{{ $singleStatus.Status }}</td>
             {{ end }}
-            <td>{{ $singleStatus.ProjectID }}</td>
-            <td>{{ $singleStatus.ClusterName }}</td>
             <td>{{ $singleStatus.UpdatedTime }}</td>
-            <td>{{ $singleStatus.TestID }}</td>
-            <td>{{ $singleStatus.Branch }}</td>
             {{ if eq $singleStatus.FiredTimes 0 }}
                 <td style="color: green">{{ $singleStatus.FiredTimes }}</td>
             {{ else }}
                 <td style="color: red">{{ $singleStatus.FiredTimes }}</td>
             {{ end }}
+            <td>{{ $singleStatus.LastFiredTime }}</td>
             <td>{{ $singleStatus.Description }}</td>
         </tr>
         {{ end}}
     </tbody>
 </table>
+</div>
 {{ end}}

--- a/policybot/dashboard/topics/releasequalification/page.html
+++ b/policybot/dashboard/topics/releasequalification/page.html
@@ -10,6 +10,14 @@
     </div>
 </aside>
 
+<p>
+    This dashboard shows results of release qualification pipeline
+</p>
+
+<p>
+    To view the monitor/alert definition, checkout <a href="https://github.com/istio/tools/blob/master/perf/stability/alertmanager/prometheusrule.yaml">PrometheusRule list</a>
+</p>
+
 {{ range $branch, $aggregatedStatus := .StatusByBranch }}
 <table>
     <caption>Monitor Status for {{ $branch }}</caption>
@@ -21,7 +29,9 @@
         <th>ClusterName</th>
         <th>UpdatedTime</th>
         <th>TestID</th>
+        <th>Branch/SHA/Tag</th>
         <th>FiredTimes</th>
+        <th>Description</th>
     </tr>
     </thead>
     <tbody>
@@ -37,11 +47,13 @@
             <td>{{ $singleStatus.ClusterName }}</td>
             <td>{{ $singleStatus.UpdatedTime }}</td>
             <td>{{ $singleStatus.TestID }}</td>
+            <td>{{ $singleStatus.Branch }}</td>
             {{ if eq $singleStatus.FiredTimes 0 }}
                 <td style="color: green">{{ $singleStatus.FiredTimes }}</td>
             {{ else }}
                 <td style="color: red">{{ $singleStatus.FiredTimes }}</td>
             {{ end }}
+            <td>{{ $singleStatus.Description }}</td>
         </tr>
         {{ end}}
     </tbody>

--- a/policybot/dashboard/topics/releasequalification/topic.go
+++ b/policybot/dashboard/topics/releasequalification/topic.go
@@ -43,6 +43,8 @@ type SingleMonitorStatus struct {
 	TestID      string
 	ProjectID   string
 	ClusterName string
+	Branch      string
+	Description string
 	FiredTimes  int64
 	UpdatedTime time.Time
 }
@@ -110,7 +112,9 @@ func (r *ReleaseQualification) getMonitorStatus(context context.Context) (Monito
 			sms.ClusterName = monitor.ClusterName
 			sms.ProjectID = monitor.ProjectID
 			sms.TestID = monitor.TestID
-			sms.FiredTimes = monitor.FiredTimes
+			sms.Branch = monitor.Branch
+			sms.Description = monitor.Description.String()
+			sms.FiredTimes = monitor.FiredTimes.Int64
 		}
 		return nil
 	}); err != nil {

--- a/policybot/dashboard/topics/releasequalification/topic.go
+++ b/policybot/dashboard/topics/releasequalification/topic.go
@@ -38,15 +38,24 @@ type ReleaseQualification struct {
 
 // SingleMonitorStatus represents the status of one single monitor
 type SingleMonitorStatus struct {
-	Name        string
-	Status      string
-	TestID      string
-	ProjectID   string
-	ClusterName string
-	Branch      string
-	Description string
-	FiredTimes  int64
-	UpdatedTime time.Time
+	Name          string
+	Status        string
+	TestID        string
+	Branch        string
+	Description   string
+	FiredTimes    int64
+	LastFiredTime string
+	UpdatedTime   time.Time
+}
+
+// TestMetadata represents the metadata about one test
+type TestMetadata struct {
+	ProjectID      string
+	ClusterName    string
+	Branch         string
+	GrafanaLink    string
+	PrometheusLink string
+	TestID         string
 }
 
 // AggregatedMonitorStatus is aggregation of monitor statuses, key is the monitor name.
@@ -54,8 +63,9 @@ type AggregatedMonitorStatus map[string]*SingleMonitorStatus
 
 // MonitorReport represents the data used for rendering the HTML page.
 type MonitorReport struct {
-	Branches       []string
-	StatusByBranch map[string]AggregatedMonitorStatus
+	TestIDs          []string
+	StatusByTestID   map[string]AggregatedMonitorStatus
+	MetadataByTestID map[string]*TestMetadata
 }
 
 // New creates a new ReleaseQualification instance.
@@ -86,42 +96,68 @@ func (r *ReleaseQualification) Render(req *http.Request) (types.RenderInfo, erro
 
 func (r *ReleaseQualification) getMonitorStatus(context context.Context) (MonitorReport, error) {
 	var mr MonitorReport
-	// StatusByBranch is mapping from branch name to aggregatedMonitorStatus
-	mr.StatusByBranch = make(map[string]AggregatedMonitorStatus)
+	// StatusByTestID is mapping from testID to aggregatedMonitorStatus
+	mr.StatusByTestID = make(map[string]AggregatedMonitorStatus)
+	mr.MetadataByTestID = make(map[string]*TestMetadata)
 
 	if err := r.store.QueryMonitorStatus(context, func(monitor *storage.Monitor) error {
-		branch := monitor.Branch
-		if branch == "" {
-			log.Warn("monitor branch is empty")
+		testID := monitor.TestID
+		if testID == "" {
+			log.Warn("testID is empty")
 			return nil
 		}
-		if _, ok := mr.StatusByBranch[branch]; !ok {
-			mr.Branches = append(mr.Branches, branch)
-			mr.StatusByBranch[branch] = make(AggregatedMonitorStatus)
+		if _, ok := mr.StatusByTestID[testID]; !ok {
+			mr.TestIDs = append(mr.TestIDs, testID)
+			mr.StatusByTestID[testID] = make(AggregatedMonitorStatus)
 		}
-		ms := mr.StatusByBranch[branch]
+		ms := mr.StatusByTestID[testID]
 		monitorName := monitor.MonitorName
 		if _, ok := ms[monitorName]; !ok {
 			ms[monitorName] = &SingleMonitorStatus{}
 		}
+
 		sms := ms[monitorName]
 		if sms.UpdatedTime.IsZero() || sms.UpdatedTime.Before(monitor.UpdatedTime) {
 			sms.Name = monitorName
 			sms.Status = monitor.Status
 			sms.UpdatedTime = monitor.UpdatedTime
-			sms.ClusterName = monitor.ClusterName
-			sms.ProjectID = monitor.ProjectID
 			sms.TestID = monitor.TestID
-			sms.Branch = monitor.Branch
 			sms.Description = monitor.Description.String()
 			sms.FiredTimes = monitor.FiredTimes.Int64
+			if monitor.LastFiredTime.Valid && !monitor.LastFiredTime.Time.IsZero() {
+				sms.LastFiredTime = monitor.LastFiredTime.String()
+			}
 		}
 		return nil
 	}); err != nil {
 		return mr, err
 	}
-	for branch, ags := range mr.StatusByBranch {
-		log.Infof("monitor status for branch: %v\n", branch)
+
+	if err := r.store.QueryReleaseQualTestMetadata(context, func(metadata *storage.ReleaseQualTestMetadata) error {
+		testID := metadata.TestID
+		if testID == "" {
+			log.Warn("testID is empty")
+			return nil
+		}
+
+		md := mr.MetadataByTestID
+		if md[testID] == nil {
+			md[testID] = &TestMetadata{
+				TestID:         testID,
+				ProjectID:      metadata.ProjectID,
+				ClusterName:    metadata.ClusterName,
+				Branch:         metadata.Branch,
+				PrometheusLink: metadata.PrometheusLink.String(),
+				GrafanaLink:    metadata.GrafanaLink.String(),
+			}
+		}
+
+		return nil
+	}); err != nil {
+		return mr, err
+	}
+	for testID, ags := range mr.StatusByTestID {
+		log.Infof("monitor status for testID: %v\n", testID)
 		for _, sgs := range ags {
 			log.Infof("single status: %v\n", sgs)
 		}

--- a/policybot/pkg/storage/spanner/query.go
+++ b/policybot/pkg/storage/spanner/query.go
@@ -83,6 +83,22 @@ func (s store) QueryMonitorStatus(context context.Context, cb func(*storage.Moni
 	return err
 }
 
+// QueryReleaseQualTestMeta queries meta info of release qualification test
+func (s store) QueryReleaseQualTestMetadata(context context.Context, cb func(metadata *storage.ReleaseQualTestMetadata) error) error {
+	iter := s.client.Single().Query(context,
+		spanner.Statement{SQL: "SELECT * FROM ReleaseQualTestMetadata"})
+	err := iter.Do(func(row *spanner.Row) error {
+		monitor := &storage.ReleaseQualTestMetadata{}
+		if err := rowToStruct(row, monitor); err != nil {
+			return err
+		}
+
+		return cb(monitor)
+	})
+
+	return err
+}
+
 func (s store) QueryIssues(context context.Context, orgLogin string, cb func(*storage.Issue) error) error {
 	iter := s.client.Single().Query(context,
 		spanner.Statement{SQL: fmt.Sprintf("SELECT * FROM Issues WHERE OrgLogin = '%s';", orgLogin)})

--- a/policybot/pkg/storage/store.go
+++ b/policybot/pkg/storage/store.go
@@ -97,6 +97,8 @@ type Store interface {
 	QueryTestFlakeIssues(context context.Context, orgLogin string, repoName string, inactiveDays, createdDays int) ([]*Issue, error)
 	// QueryMonitorStatus queries monitor status of release qualification test
 	QueryMonitorStatus(context context.Context, cb func(*Monitor) error) error
+	// QueryReleaseQualTestMetadata queries release qualification test metadata
+	QueryReleaseQualTestMetadata(context context.Context, cb func(metadata *ReleaseQualTestMetadata) error) error
 
 	GetLatestIssueMemberActivity(context context.Context, orgLogin string, repoName string, issueNumber int) (time.Time, error)
 	GetLatestIssueMemberComment(context context.Context, orgLogin string, repoName string, issueNumber int) (time.Time, error)

--- a/policybot/pkg/storage/types.go
+++ b/policybot/pkg/storage/types.go
@@ -16,6 +16,8 @@ package storage
 
 import (
 	"time"
+
+	"cloud.google.com/go/spanner"
 )
 
 // This file defines the shapes we csn read/write to/from the DB. Before
@@ -147,10 +149,12 @@ type Monitor struct {
 	TestID      string
 	// Branch of the test, e.g. release-1.7
 	Branch string
+	// Description of the monitor
+	Description spanner.NullString
 	// UpdatedTime represents the time of the monitor status update
 	UpdatedTime time.Time
 	// FiredTimes represents the number of times the monitor fired alerts.
-	FiredTimes int64
+	FiredTimes spanner.NullInt64
 	IsActive   *bool
 }
 

--- a/policybot/pkg/storage/types.go
+++ b/policybot/pkg/storage/types.go
@@ -153,9 +153,27 @@ type Monitor struct {
 	Description spanner.NullString
 	// UpdatedTime represents the time of the monitor status update
 	UpdatedTime time.Time
+	// LastFiredTime represents the last timestamp when the alert is fired.
+	LastFiredTime spanner.NullTime
 	// FiredTimes represents the number of times the monitor fired alerts.
 	FiredTimes spanner.NullInt64
 	IsActive   *bool
+}
+
+// ReleaseQualTestMetadata represents the metadata of specific test run.
+type ReleaseQualTestMetadata struct {
+	// ProjectID points to the project where the test is running
+	ProjectID string
+	// ClusterName points to the cluster where the test is running
+	ClusterName string
+	// TestID is the ID of specific Test run
+	TestID string
+	// Branch of the test, e.g. release-1.7
+	Branch string
+	// PrometheusLink links to prometheus running in the cluster
+	PrometheusLink spanner.NullString
+	// GrafanaLink links to prometheus running in the cluster
+	GrafanaLink spanner.NullString
 }
 
 type BotActivity struct {

--- a/policybot/spanner.ddl
+++ b/policybot/spanner.ddl
@@ -227,8 +227,10 @@ CREATE TABLE MonitorStatus (
   ProjectID STRING(MAX) NOT NULL,
   TestID STRING(MAX),
   Branch STRING(MAX) NOT NULL,
+  Description STRING(MAX),
   UpdatedTime TIMESTAMP NOT NULL,
   FiredTimes INT64 NOT NULL,
+  Description STRING(MAX),
   IsActive BOOL,
 ) PRIMARY KEY(TestID, MonitorName)
 

--- a/policybot/spanner.ddl
+++ b/policybot/spanner.ddl
@@ -223,16 +223,22 @@ CREATE TABLE RepoComments (
 CREATE TABLE MonitorStatus (
   MonitorName STRING(MAX) NOT NULL,
   Status STRING(MAX) NOT NULL,
-  ClusterName STRING(MAX) NOT NULL,
-  ProjectID STRING(MAX) NOT NULL,
-  TestID STRING(MAX),
-  Branch STRING(MAX) NOT NULL,
+  TestID STRING(MAX) NOT NULL,
   Description STRING(MAX),
   UpdatedTime TIMESTAMP NOT NULL,
   FiredTimes INT64 NOT NULL,
-  Description STRING(MAX),
+  LastFiredTime TIMESTAMP,
   IsActive BOOL,
 ) PRIMARY KEY(TestID, MonitorName)
+
+CREATE TABLE ReleaseQualTestMetadata (
+  ClusterName STRING(MAX) NOT NULL,
+  ProjectID STRING(MAX) NOT NULL,
+  TestID STRING(MAX) NOT NULL,
+  Branch STRING(MAX) NOT NULL,
+  PrometheusLink STRING(MAX),
+  GrafanaLink STRING(MAX),
+) PRIMARY KEY(TestID)
 
 CREATE TABLE TestResults (
   OrgLogin STRING(MAX) NOT NULL,


### PR DESCRIPTION
breaks down the original MonitorStatus table to TestMetadata and MonitorStatus table so that the information would be shown more clearly on the page