### PR TITLE
Add 'Upgrade' to the autolabeler config

### DIFF
--- a/policybot/config/autolabels/upgrade.yaml
+++ b/policybot/config/autolabels/upgrade.yaml
@@ -1,0 +1,8 @@
+name: Upgrade
+type: autolabel
+matchbody:
+  - "\\[ ?x ?\\] ?Upgrade"
+absentlabels:
+  - "area/.?"
+labelstoapply:
+  - area/upgrade


### PR DESCRIPTION
Adds autolabeler config for the addition of `Upgrade []` to the [istio/istio bug report issue template](https://github.com/istio/istio/pull/28702)
