### PR TITLE
remove old cherrypick labels

### DIFF
--- a/policybot/config/labels/cherrypick-release-1.5.yaml
+++ b/policybot/config/labels/cherrypick-release-1.5.yaml
@@ -1,4 +1,0 @@
-name: cherrypick/release-1.5
-type: label
-color: ff0000
-description: Set this label on a PR to auto-merge it to the release-1.5 branch

--- a/policybot/config/labels/cherrypick-release-1.6.yaml
+++ b/policybot/config/labels/cherrypick-release-1.6.yaml
@@ -1,4 +1,0 @@
-name: cherrypick/release-1.6
-type: label
-color: ff0000
-description: Set this label on a PR to auto-merge it to the release-1.6 branch


### PR DESCRIPTION
As `1.5` and `1.6` milestones are already closed. we don't need these `cherrypick` labels.

Ref: https://github.com/istio/bots/pull/308

