### PR TITLE
Add product security label

### DIFF
--- a/policybot/config/labels/product-security.yaml
+++ b/policybot/config/labels/product-security.yaml
@@ -1,0 +1,4 @@
+name: 'area/product security'
+type: label
+color: dbc1bf
+description: Indicates an issue affecting Istio security. Do not use for vulnerabilities.


### PR DESCRIPTION
This adds a label to track proactive and reporting work by the product security workgroup. It **should not** be used for vulnerabilities.