### PR TITLE
update the projectId to be spanner nullstring

### DIFF
--- a/policybot/pkg/storage/types.go
+++ b/policybot/pkg/storage/types.go
@@ -143,7 +143,8 @@ type Monitor struct {
 	// Status represents the status of the monitor, e.g. HEALTHY, ALERTING
 	Status string
 	// ProjectID points to the project where the test is running
-	ProjectID string
+	// Optional: keep it for backward compatibility
+	ProjectID spanner.NullString
 	// ClusterName points to the cluster where the test is running
 	ClusterName string
 	TestID      string

--- a/policybot/spanner.ddl
+++ b/policybot/spanner.ddl
@@ -223,6 +223,7 @@ CREATE TABLE RepoComments (
 CREATE TABLE MonitorStatus (
   MonitorName STRING(MAX) NOT NULL,
   Status STRING(MAX) NOT NULL,
+  ProjectID STRING(MAX),
   TestID STRING(MAX) NOT NULL,
   Description STRING(MAX),
   UpdatedTime TIMESTAMP NOT NULL,


### PR DESCRIPTION
For backward compatibility: the newly published monitor status of the release qualification test does not contain projectID in the monitorStatus table anymore