### PR TITLE
Fix release note label

### DIFF
--- a/policybot/config/autolabels/release-notes.yaml
+++ b/policybot/config/autolabels/release-notes.yaml
@@ -1,6 +1,6 @@
 name: Release-notes-none
 type: autolabel
 matchbody:
-  - "\\[ ?x ?\\] ?Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc."
+  - "\\[ ?x ?\\] ?Does not have any \\[user-facing\\].*changes."
 labelstoapply:
   - release-notes-none


### PR DESCRIPTION
Fixes the regex for the release notes label. https://play.golang.org/p/vEXEk66lB7P