### PR TITLE
Add tests for clean regex matches

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module istio.io/bots
 
-go 1.12
+go 1.13
 
 // Old version had no license
 replace github.com/chzyer/logex => github.com/chzyer/logex v1.1.11-0.20170329064859-445be9e134b2
@@ -11,6 +11,7 @@ require (
 	cloud.google.com/go/storage v1.10.0
 	github.com/eapache/channels v1.1.0
 	github.com/ghodss/yaml v1.0.0
+	github.com/google/go-cmp v0.5.1
 	github.com/google/go-github/v26 v26.0.9
 	github.com/gorilla/mux v1.7.1
 	github.com/gorilla/websocket v1.4.1

--- a/policybot/config/boilerplates/area-selection.yaml
+++ b/policybot/config/boilerplates/area-selection.yaml
@@ -1,14 +1,13 @@
 name: Area selection
 type: boilerplate
 regex: |
-  ^\[ ?[ \w] ?\] +Configuration Infrastructure
-  \[ ?[ \w] ?\] +Docs
-  \[ ?[ \w] ?\] +Installation
-  \[ ?[ \w] ?\] +Networking
-  \[ ?[ \w] ?\] +Performance and Scalability
-  \[ ?[ \w] ?\] +Policies and Telemetry
-  \[ ?[ \w] ?\] +Security
-  \[ ?[ \w] ?\] +Test and Release
-  \[ ?[ \w] ?\] +User Experience
-  \[ ?[ \w] ?\] +Developer Infrastructure
-  \[ ?[ \w] ?\] +Product Security
+  ^\[[ \w]\] +Docs
+  \[[ \w]\] +Installation
+  \[[ \w]\] +Networking
+  \[[ \w]\] +Performance and Scalability
+  \[[ \w]\] +Extensions and Telemetry
+  \[[ \w]\] +Security
+  \[[ \w]\] +Test and Release
+  \[[ \w]\] +User Experience
+  \[[ \w]\] +Developer Infrastructure
+  \[[ \w]\] +Upgrade

--- a/policybot/config/boilerplates/note-about-bugs.yaml
+++ b/policybot/config/boilerplates/note-about-bugs.yaml
@@ -1,7 +1,6 @@
 name: Note about bugs
 type: boilerplate
 regex: |
-  \(NOTE: This is used to report product bugs:
-    To report a security vulnerability, please visit <https://istio.io/about/security-vulnerabilities/>
-    To ask questions about how to use Istio, please visit <https://discuss\.istio\.io>
-  \)
+  \(\*\*NOTE\*\*: This is used to report product bugs:
+    To report a security vulnerability, please visit <https://istio\.io/about/security-vulnerabilities>
+    To ask questions about how to use Istio, please visit <https://discuss\.istio\.io>\)

--- a/policybot/handlers/githubwebhook/cleaner/cleaner_test.go
+++ b/policybot/handlers/githubwebhook/cleaner/cleaner_test.go
@@ -1,0 +1,117 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cleaner
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/ghodss/yaml"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestBoilerplates(t *testing.T) {
+	configPath := "../../../config/boilerplates"
+	configDir, err := ioutil.ReadDir(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name     string
+		matchers []string
+	}{
+		{
+			"issue-default",
+			[]string{
+				"area-selection",
+				"area-selection-banner",
+				"feature-selection",
+				"feature-selection-banner",
+				"note-about-bugs",
+			},
+		},
+	}
+	boilerplates := map[string]*regexp.Regexp{}
+	for _, bp := range configDir {
+		f, err := os.ReadFile(filepath.Join(configPath, bp.Name()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		name := strings.TrimSuffix(bp.Name(), ".yaml")
+		var rec boilerplateRecord
+		if err := yaml.Unmarshal(f, &rec); err != nil {
+			t.Fatal(err)
+		}
+		rx, err := regexp.Compile("(?mis)" + rec.Regex)
+		if err != nil {
+			t.Fatal(err)
+		}
+		boilerplates[name] = rx
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			input, err := os.ReadFile(filepath.Join("testdata", tt.name+".txt"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			expected := map[string]bool{}
+			for _, m := range tt.matchers {
+				expected[m] = true
+			}
+
+			result := string(input)
+			for bn, rx := range boilerplates {
+				matched := rx.Match(input)
+				if matched != expected[bn] {
+					t.Errorf("expected match=%v, got match=%v for %v", expected[bn], matched, bn)
+				}
+				// Code allows custom replacement but its never used, so for now just test replace with empty
+				result = rx.ReplaceAllString(result, "")
+			}
+			gp := filepath.Join("testdata", tt.name+".out.txt")
+			if _, f := os.LookupEnv("REFRESH_GOLDEN"); f {
+				if err := os.WriteFile(gp, []byte(result), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			expectedResult, err := os.ReadFile(gp)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(result, string(expectedResult)); diff != "" {
+				t.Fatalf("did not get expected output. diff: %v", diff)
+			}
+		})
+	}
+	t.Run("coverage", func(t *testing.T) {
+		t.Skip("Enable after https://github.com/istio/istio/issues/34839 to avoid wasted effort")
+		for _, tt := range cases {
+			for _, m := range tt.matchers {
+				delete(boilerplates, m)
+			}
+		}
+		if len(boilerplates) > 0 {
+			for k := range boilerplates {
+				t.Logf("Missing %v", k)
+			}
+			t.Fatalf("Not all boilerplates included in positive tests")
+		}
+	})
+}

--- a/policybot/handlers/githubwebhook/cleaner/testdata/issue-default.out.txt
+++ b/policybot/handlers/githubwebhook/cleaner/testdata/issue-default.out.txt
@@ -1,0 +1,19 @@
+
+**Bug description**
+
+
+
+
+
+**Expected behavior**
+
+**Steps to reproduce the bug**
+
+**Version** (include the output of `istioctl version --remote` and `kubectl version --short` and `helm version --short` if you used Helm)
+
+**How was Istio installed?**
+
+**Environment where the bug was observed (cloud vendor, OS, etc)**
+
+Additionally, please consider running `istioctl bug-report` and attach the generated cluster-state tarball to this issue.
+Refer [cluster state archive](http://istio.io/help/bugs/#generating-a-cluster-state-archive) for more details.

--- a/policybot/handlers/githubwebhook/cleaner/testdata/issue-default.txt
+++ b/policybot/handlers/githubwebhook/cleaner/testdata/issue-default.txt
@@ -1,0 +1,37 @@
+(**NOTE**: This is used to report product bugs:
+  To report a security vulnerability, please visit <https://istio.io/about/security-vulnerabilities>
+  To ask questions about how to use Istio, please visit <https://discuss.istio.io>)
+
+**Bug description**
+
+**Affected product area (please put an X in all that apply)**
+
+[ ] Docs
+[ ] Installation
+[ ] Networking
+[ ] Performance and Scalability
+[ ] Extensions and Telemetry
+[ ] Security
+[ ] Test and Release
+[ ] User Experience
+[ ] Developer Infrastructure
+[ ] Upgrade
+
+**Affected features (please put an X in all that apply)**
+
+[ ] Multi Cluster
+[ ] Virtual Machine
+[ ] Multi Control Plane
+
+**Expected behavior**
+
+**Steps to reproduce the bug**
+
+**Version** (include the output of `istioctl version --remote` and `kubectl version --short` and `helm version --short` if you used Helm)
+
+**How was Istio installed?**
+
+**Environment where the bug was observed (cloud vendor, OS, etc)**
+
+Additionally, please consider running `istioctl bug-report` and attach the generated cluster-state tarball to this issue.
+Refer [cluster state archive](http://istio.io/help/bugs/#generating-a-cluster-state-archive) for more details.


### PR DESCRIPTION
A precursor to https://github.com/istio/istio/issues/34839, which will
change the format. Now we can make sure it actually works. This fixes a
couple issues with the current regex's, but I don't want to invest much
more time on it since we are going to change them all anyways.