### PR TITLE
Update docker image Ubuntu to jammy

### DIFF
--- a/policybot/Dockerfile
+++ b/policybot/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:groovy
+FROM ubuntu:jammy
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \


### PR DESCRIPTION
The post submit job is failing to crate the docker image: https://prow.istio.io/log?container=test&id=1517483843722940416&job=deploy-policybot_bots_postsubmit
```
Step 1/5 : FROM ubuntu:groovy
groovy: Pulling from library/ubuntu
32f3531c8415: Pulling fs layer
32f3531c8415: Verifying Checksum
32f3531c8415: Download complete
32f3531c8415: Pull complete
Digest: sha256:a7b08558af07bcccca994b01e1c84f1d14a2156e0099fcf7fcf73f52d082791e
Status: Downloaded newer image for ubuntu:groovy
 ---> e508bd6d694e
Step 2/5 : RUN apt-get update && apt-get install -y --no-install-recommends     ca-certificates     && apt-get clean && rm -rf /var/lib/apt/lists/*
 ---> Running in 1c8ee24227d2
Ign:1 http://security.ubuntu.com/ubuntu groovy-security InRelease
Ign:2 http://archive.ubuntu.com/ubuntu groovy InRelease
Err:3 http://security.ubuntu.com/ubuntu groovy-security Release
  404  Not Found [IP: 185.125.190.39 80]
Ign:4 http://archive.ubuntu.com/ubuntu groovy-updates InRelease
Ign:5 http://archive.ubuntu.com/ubuntu groovy-backports InRelease
Err:6 http://archive.ubuntu.com/ubuntu groovy Release
  404  Not Found [IP: 185.125.190.39 80]
Err:7 http://archive.ubuntu.com/ubuntu groovy-updates Release
  404  Not Found [IP: 185.125.190.39 80]
Err:8 http://archive.ubuntu.com/ubuntu groovy-backports Release
  404  Not Found [IP: 185.125.190.39 80]
```
as `groovy` is EOL. 

Update to use the just released `jammy`