### PR TITLE
Remove the 4th parameter in `window.open` and fix TSLint `array-type` rule violation

### DIFF
--- a/policybot/dashboard/ts/core/event.ts
+++ b/policybot/dashboard/ts/core/event.ts
@@ -20,7 +20,7 @@ interface ILiteEvent<T> {
 }
 
 class LiteEvent<T> implements ILiteEvent<T> {
-    private handlers: Array<HandlerFn<T>> = new Array<HandlerFn<T>>();
+    private handlers: HandlerFn<T>[] = [];
 
     public on(handler: HandlerFn<T>): void {
         this.handlers.push(handler);

--- a/policybot/dashboard/ts/core/utils.ts
+++ b/policybot/dashboard/ts/core/utils.ts
@@ -70,7 +70,7 @@ function saveFile(filename: string, text: string): void {
 function printText(text: string): void {
     const html = "<html><body><pre><code>" + text + "</code></pre></html>";
 
-    const printWin = window.open("", "", "left=0,top=0,width=100,height=100,toolbar=0,scrollbars=0,status=0,location=0,menubar=0", false);
+    const printWin = window.open("", "", "left=0,top=0,width=100,height=100,toolbar=0,scrollbars=0,status=0,location=0,menubar=0");
     if (printWin) {
         printWin.document.write(html);
         printWin.document.close();


### PR DESCRIPTION
- Remove the 4th parameter in `window.open`. The parameter is not in the HTML specification and might cause an exception in certain version of Chrome. ([Discussion on bugs.chromium.org](https://bugs.chromium.org/p/chromium/issues/detail?id=1164959))
- Fix TSLint [`array-type` rule](https://palantir.github.io/tslint/rules/array-type/). The rule is introduced in a more recent version of TSLint and will cause an error in `policybot/dashboard/ts/core/event.ts`