### PR TITLE
Add dual stack label to support experimental support triaging

### DIFF
--- a/policybot/config/autolabels/dualstack.yaml
+++ b/policybot/config/autolabels/dualstack.yaml
@@ -1,0 +1,9 @@
+name: Dual-stack
+type: autolabel
+matchbody:
+  - "\\[ ?x ?\\] ?Dual Stack"
+absentlabels:
+  - "area/.?"
+labelstoapply:
+  - area/networking
+  - area/dual-stack

--- a/policybot/config/boilerplates/area-selection.yaml
+++ b/policybot/config/boilerplates/area-selection.yaml
@@ -6,6 +6,7 @@ regex: |
 
   - \[[ \w]\] +Ambient
   - \[[ \w]\] +Docs
+  - \[[ \w]\] +Dual Stack
   - \[[ \w]\] +Installation
   - \[[ \w]\] +Networking
   - \[[ \w]\] +Performance and Scalability

--- a/policybot/handlers/githubwebhook/cleaner/testdata/issue-default.txt
+++ b/policybot/handlers/githubwebhook/cleaner/testdata/issue-default.txt
@@ -23,6 +23,7 @@ No thanks
 
 - [ ] Ambient
 - [ ] Docs
+- [ ] Dual Stack
 - [ ] Installation
 - [ ] Networking
 - [ ] Performance and Scalability


### PR DESCRIPTION
support triaging in Istio 1.17+

Followed the pattern for `Virutal Machines`. Most users should pick this in addition to `networking`