### PR TITLE
Further changes for v1

### DIFF
--- a/policybot/deploy/policybot/templates/ingress.yaml
+++ b/policybot/deploy/policybot/templates/ingress.yaml
@@ -12,5 +12,7 @@ metadata:
     ingress.kubernetes.io/force-ssl-redirect: "true"
 spec:
   defaultBackend:
-    service.name: policybot-server
-    service.port.name: 8080
+    service:
+      name: policybot-server
+      port:
+        number: 8080


### PR DESCRIPTION
Another crack at this.

The prior change had the following errors in the log: 
```
error validating "STDIN": error validating data: [ValidationError(Ingress.spec.defaultBackend): unknown field "service.name" in io.k8s.api.networking.v1.IngressBackend, ValidationError(Ingress.spec.defaultBackend): unknown field "service.port.name" in io.k8s.api.networking.v1.IngressBackend]; if you choose to ignore these errors, turn validation off with --validate=false
```
Attempting to recreate the failure locally, I removed the retrieving of gcloud creds from the `deploy_only` task, and got a 
```
Error from server (BadRequest): error when creating "STDIN": Ingress in version "v1" cannot be handled as a Ingress: strict decoding error: unknown field "spec.defaultBackend.service.name", unknown field "spec.defaultBackend.service.port.number"
``` 
error.
I reformatted the yaml fields to fix that error.
I also changed the port to `number` since the docs call out number for an integer and name for a string.