### PR TITLE
[CNCF graduation] Add security tab for Istio repos

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,1 @@
+Refer to [Istio Security Overview](https://github.com/istio/istio/blob/master/.github/SECURITY.md) for more details.


### PR DESCRIPTION
Responsibility disclosures and reporting policies should be available in all Istio repos. Currently we have it only in https://github.com/istio/istio/security