### PR TITLE
Use do-not-merge/hold instead of do-not-merge

### DIFF
--- a/policybot/config/labels/do-not-merge-hold.yaml
+++ b/policybot/config/labels/do-not-merge-hold.yaml
@@ -1,4 +1,4 @@
-name: do-not-merge
+name: do-not-merge/hold
 type: label
 color: bfdadc
 description: Block automatic merging of a PR.


### PR DESCRIPTION
See https://github.com/kubernetes/test-infra/blob/master/label_sync/labels.md as do-not-merge is deprecated.