### PR TITLE
Fix dual stack label

### DIFF
--- a/policybot/config/autolabels/dualstack.yaml
+++ b/policybot/config/autolabels/dualstack.yaml
@@ -1,4 +1,4 @@
-name: Dual-stack
+name: Dual Stack
 type: autolabel
 matchbody:
   - "\\[ ?x ?\\] ?Dual Stack"

--- a/policybot/config/boilerplates/pr-area-selection.yaml
+++ b/policybot/config/boilerplates/pr-area-selection.yaml
@@ -6,6 +6,7 @@ regex: |
   - \[[ \w]\] +Ambient
   - \[[ \w]\] +Configuration Infrastructure
   - \[[ \w]\] +Docs
+  - \[[ \w]\] +Dual Stack
   - \[[ \w]\] +Installation
   - \[[ \w]\] +Networking
   - \[[ \w]\] +Performance and Scalability

--- a/policybot/handlers/githubwebhook/cleaner/testdata/pr-default.txt
+++ b/policybot/handlers/githubwebhook/cleaner/testdata/pr-default.txt
@@ -7,6 +7,7 @@ Something about my PR...
 - [ ] Ambient
 - [ ] Configuration Infrastructure
 - [ ] Docs
+- [ ] Dual Stack
 - [ ] Installation
 - [x] Networking
 - [ ] Performance and Scalability


### PR DESCRIPTION
Dual stack label wasn't working. Until dual-stack is alpha it shouldn't affect the networking group. I'm fine with removing it if anyone sees it better to remove.