### PR TITLE
Create `help wanted` label

### DIFF
--- a/policybot/config/labels/help-wanted.yaml
+++ b/policybot/config/labels/help-wanted.yaml
@@ -1,0 +1,4 @@
+name: help wanted
+type: label
+color: f9ddbe
+description: Indicates a PR/Issue that needs community help 


### PR DESCRIPTION
As per https://github.com/cncf/clotributor/issues/506 , Istio is not getting listed in the CNCF [CLOTributor](https://clotributor.dev/search?page=1), because we do not use the `help wanted` label, rather use `community/help wanted`. clotributor is a nice initiative for new developers to get started with CNCF projects by listing down easy to fix issues. So, if we do not have any major concerns, let us start using the new `help wanted` label and deprecate the old one? Suggestions?