### PR TITLE
Create label "good first issue"

### DIFF
--- a/policybot/config/labels/good-first-issue.yaml
+++ b/policybot/config/labels/good-first-issue.yaml
@@ -1,0 +1,4 @@
+name: good first issue
+type: label
+color: f9ddbe
+description: Indicates a good first issue for new contributors


### PR DESCRIPTION
As per https://github.com/cncf/clotributor/issues/506 , Istio is not getting listed in the CNCF [CLOTributor](https://clotributor.dev/search?page=1), because we do not use the `good first issue` label, rather use `community/good first issue`. CLOTributor is a nice initiative for new developers to get started with CNCF projects by listing down easy to fix issues. So, let us try to migrate to the new label. Once the two new labels are published, I will migrate all existing issues to use the new labels, and then remove the old labels from bots repo