### PR TITLE
Remove community-[help-wanted/good-first-issue] labels

### DIFF
--- a/policybot/config/labels/community-good-first-issue.yaml
+++ b/policybot/config/labels/community-good-first-issue.yaml
@@ -1,4 +1,0 @@
-name: community/good first issue
-type: label
-color: f9ddbe
-description: Indicates a good first issue for new contributors

--- a/policybot/config/labels/community-help-wanted.yaml
+++ b/policybot/config/labels/community-help-wanted.yaml
@@ -1,4 +1,0 @@
-name: community/help wanted
-type: label
-color: f9ddbe
-description: Indicates a PR/Issue that needs community help 


### PR DESCRIPTION
Now that we have created `help wanted` and `good first issue` labels and migrated all existing issues to use the new labels, let us remove the old labels