### PR TITLE
Remove 1.17 and 1.18 cp labels

### DIFF
--- a/policybot/config/labels/cherrypick-release-1.17.yaml
+++ b/policybot/config/labels/cherrypick-release-1.17.yaml
@@ -1,4 +1,0 @@
-name: cherrypick/release-1.17
-type: label
-color: ff0000
-description: Set this label on a PR to auto-merge it to the release-1.17 branch

--- a/policybot/config/labels/cherrypick-release-1.18.yaml
+++ b/policybot/config/labels/cherrypick-release-1.18.yaml
@@ -1,4 +1,0 @@
-name: cherrypick/release-1.18
-type: label
-color: ff0000
-description: Set this label on a PR to auto-merge it to the release-1.18 branch


### PR DESCRIPTION
Which are all EOL.

QQ: why won't removing the label here result in its removal from other repos? Currently, there are labels from 1.1 to 1.20, and most of them are no longer in use.