### PR TITLE
Mark emeritus maintainers in sync data

### DIFF
--- a/policybot/mgrs/syncmgr/mgr.go
+++ b/policybot/mgrs/syncmgr/mgr.go
@@ -80,6 +80,8 @@ type syncState struct {
 
 var scope = log.RegisterScope("syncmgr", "The GitHub data syncer")
 
+const emeritusMaintainersURL = "https://raw.githubusercontent.com/istio/community/master/org/emeritus.yaml"
+
 func New(gc *gh.ThrottledClient, store storage.Store, bq *bigquery.Client, bs blobstorage.Store,
 	reg *config.Registry, robots []string,
 ) *SyncMgr {
@@ -1278,6 +1280,10 @@ func (ss *syncState) handleMaintainers() error {
 		}
 	}
 
+	if err := ss.handleEmeritusMaintainers(maintainers); err != nil {
+		return err
+	}
+
 	// get the correct case for the maintainer login names, since they are case insensitive in the CODEOWNERS/OWNERS files
 	storageMaintainers := make([]*storage.Maintainer, 0, len(maintainers))
 	for _, maintainer := range maintainers {
@@ -1323,6 +1329,60 @@ func (ss *syncState) handleMaintainers() error {
 	}
 
 	return ss.mgr.store.WriteAllMaintainers(ss.ctx, storageMaintainers)
+}
+
+type emeritusConfig struct {
+	Emeritus []string `json:"emeritus"`
+}
+
+func readEmeritusMaintainers(r io.Reader) ([]string, error) {
+	body, err := io.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg := emeritusConfig{}
+	if err := yaml.Unmarshal(body, &cfg); err != nil {
+		return nil, err
+	}
+
+	return cfg.Emeritus, nil
+}
+
+func markEmeritusMaintainer(orgLogin string, maintainers map[string]*storage.Maintainer, user string) *storage.Maintainer {
+	key := strings.ToUpper(user)
+	maintainer, ok := maintainers[key]
+	if !ok {
+		maintainer = &storage.Maintainer{
+			OrgLogin:  orgLogin,
+			UserLogin: user,
+		}
+		maintainers[key] = maintainer
+	}
+	maintainer.Emeritus = true
+	return maintainer
+}
+
+func (ss *syncState) handleEmeritusMaintainers(maintainers map[string]*storage.Maintainer) error {
+	resp, err := http.Get(emeritusMaintainersURL)
+	if err != nil {
+		return fmt.Errorf("unable to get emeritus maintainers: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unable to get emeritus maintainers: %s", resp.Status)
+	}
+
+	emeritus, err := readEmeritusMaintainers(resp.Body)
+	if err != nil {
+		return fmt.Errorf("unable to parse emeritus maintainers: %v", err)
+	}
+
+	for _, user := range emeritus {
+		ss.addUsers(user)
+		markEmeritusMaintainer("istio", maintainers, user)
+	}
+	return nil
 }
 
 func (ss *syncState) handleCODEOWNERS(repo gh.RepoDesc, maintainers map[string]*storage.Maintainer, fc *github.RepositoryContent) error {

--- a/policybot/mgrs/syncmgr/mgr_test.go
+++ b/policybot/mgrs/syncmgr/mgr_test.go
@@ -15,7 +15,10 @@
 package syncmgr
 
 import (
+	"strings"
 	"testing"
+
+	"istio.io/bots/policybot/pkg/storage"
 )
 
 func TestConvFilterFlags(t *testing.T) {
@@ -71,5 +74,68 @@ func TestConvFilterFlags(t *testing.T) {
 			t.Errorf("%s: converting to filter expected %d but returned %d",
 				test.flag, test.expected, actual)
 		}
+	}
+}
+
+func TestReadEmeritusMaintainers(t *testing.T) {
+	emeritus, err := readEmeritusMaintainers(strings.NewReader(`
+emeritus:
+- alice
+- Bob
+release-managers:
+  Release Managers - 1.0:
+    members:
+    - carol
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := strings.Join(emeritus, ","), "alice,Bob"; got != want {
+		t.Fatalf("unexpected emeritus maintainers: got %q want %q", got, want)
+	}
+}
+
+func TestMarkEmeritusMaintainerPreservesActiveMaintainerPaths(t *testing.T) {
+	maintainers := map[string]*storage.Maintainer{
+		"ALICE": {
+			OrgLogin:  "istio",
+			UserLogin: "alice",
+			Paths:     []string{"istio/pilot/"},
+		},
+	}
+
+	maintainer := markEmeritusMaintainer("istio", maintainers, "Alice")
+
+	if !maintainer.Emeritus {
+		t.Fatal("maintainer was not marked emeritus")
+	}
+	if got, want := maintainer.UserLogin, "alice"; got != want {
+		t.Fatalf("unexpected maintainer login: got %q want %q", got, want)
+	}
+	if got, want := strings.Join(maintainer.Paths, ","), "istio/pilot/"; got != want {
+		t.Fatalf("unexpected maintainer paths: got %q want %q", got, want)
+	}
+	if len(maintainers) != 1 {
+		t.Fatalf("expected existing maintainer entry to be reused, got %d entries", len(maintainers))
+	}
+}
+
+func TestMarkEmeritusMaintainerAddsNewMaintainer(t *testing.T) {
+	maintainers := map[string]*storage.Maintainer{}
+
+	maintainer := markEmeritusMaintainer("istio", maintainers, "alice")
+
+	if !maintainer.Emeritus {
+		t.Fatal("maintainer was not marked emeritus")
+	}
+	if got, want := maintainer.OrgLogin, "istio"; got != want {
+		t.Fatalf("unexpected org login: got %q want %q", got, want)
+	}
+	if got, want := maintainer.UserLogin, "alice"; got != want {
+		t.Fatalf("unexpected user login: got %q want %q", got, want)
+	}
+	if _, ok := maintainers["ALICE"]; !ok {
+		t.Fatal("maintainer was not keyed case-insensitively")
 	}
 }


### PR DESCRIPTION
## What this changes

- Reads the Istio community emeritus maintainer list during maintainer sync.
- Marks matching active maintainers as emeritus while preserving their existing maintained paths.
- Adds emeritus-only users to the maintainer storage data so downstream views can display them.
- Adds tests for parsing the emeritus list and case-insensitive maintainer marking.

Fixes istio/community#976.

## Testing

- GOCACHE=/private/tmp/istio-bots-go-cache GOMODCACHE=/private/tmp/istio-bots-go-mod-cache go test ./policybot/mgrs/syncmgr